### PR TITLE
Implement game state management with Context API (#10)

### DIFF
--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -1,0 +1,430 @@
+// context/GameContext.tsx
+
+import {
+  createContext,
+  useContext,
+  useReducer,
+  useCallback,
+  useMemo,
+  type ReactNode,
+} from 'react';
+
+import type { Card, GameMode, GamePhase, Role, RoundHistory } from '../types';
+import { drawCards } from '../utils/deck';
+import { calculateRole, determineWinner } from '../utils/roleCalculator';
+
+/** ゲームの総ラウンド数 */
+const TOTAL_ROUNDS = 5;
+
+/** 手札の枚数 */
+const HAND_SIZE = 5;
+
+/** ゲーム状態 */
+export interface GameState {
+  mode: GameMode;
+  phase: GamePhase;
+  round: number;
+  playerHand: Card[];
+  dealerHand: Card[];
+  selectedCardIds: number[];
+  playerRole: Role | null;
+  dealerRole: Role | null;
+  playerScore: number;
+  dealerScore: number;
+  roundHistory: RoundHistory[];
+  excludedCardIds: number[];
+}
+
+/** 初期ゲーム状態 */
+export const initialGameState: GameState = {
+  mode: 'solo',
+  phase: 'dealing',
+  round: 1,
+  playerHand: [],
+  dealerHand: [],
+  selectedCardIds: [],
+  playerRole: null,
+  dealerRole: null,
+  playerScore: 0,
+  dealerScore: 0,
+  roundHistory: [],
+  excludedCardIds: [],
+};
+
+/** アクション型 */
+type GameAction =
+  | { type: 'START_GAME'; payload: { mode: GameMode } }
+  | { type: 'SET_HANDS'; payload: { playerHand: Card[]; dealerHand: Card[] } }
+  | { type: 'SET_PHASE'; payload: { phase: GamePhase } }
+  | { type: 'SELECT_CARD'; payload: { cardId: number } }
+  | {
+      type: 'EXCHANGE_CARDS';
+      payload: { newCards: Card[]; exchangedCardIds: number[] };
+    }
+  | { type: 'SKIP_EXCHANGE' }
+  | {
+      type: 'SET_ROLES';
+      payload: { playerRole: Role; dealerRole: Role | null };
+    }
+  | {
+      type: 'UPDATE_SCORES';
+      payload: {
+        playerPoints: number;
+        dealerPoints: number;
+        result?: 'win' | 'lose' | 'draw';
+      };
+    }
+  | { type: 'NEXT_ROUND' }
+  | { type: 'FINISH_GAME' }
+  | { type: 'RESET_GAME' };
+
+/**
+ * ゲーム状態のReducer
+ */
+function gameReducer(state: GameState, action: GameAction): GameState {
+  switch (action.type) {
+    case 'START_GAME': {
+      return {
+        ...initialGameState,
+        mode: action.payload.mode,
+        phase: 'dealing',
+      };
+    }
+
+    case 'SET_HANDS': {
+      const { playerHand, dealerHand } = action.payload;
+      // 除外リストに追加
+      const newExcludedIds = [
+        ...playerHand.map((c) => c.id),
+        ...dealerHand.map((c) => c.id),
+      ];
+      return {
+        ...state,
+        playerHand,
+        dealerHand,
+        excludedCardIds: newExcludedIds,
+        phase: 'selecting',
+      };
+    }
+
+    case 'SET_PHASE': {
+      return {
+        ...state,
+        phase: action.payload.phase,
+      };
+    }
+
+    case 'SELECT_CARD': {
+      const { cardId } = action.payload;
+      const isSelected = state.selectedCardIds.includes(cardId);
+      const newSelectedIds = isSelected
+        ? state.selectedCardIds.filter((id) => id !== cardId)
+        : [...state.selectedCardIds, cardId];
+      return {
+        ...state,
+        selectedCardIds: newSelectedIds,
+      };
+    }
+
+    case 'EXCHANGE_CARDS': {
+      const { newCards, exchangedCardIds } = action.payload;
+      // 交換されたカードを新しいカードに置き換え
+      const newPlayerHand = state.playerHand.map((card) => {
+        const index = exchangedCardIds.indexOf(card.id);
+        if (index !== -1) {
+          return newCards[index];
+        }
+        return card;
+      });
+      // 除外リストに新しいカードを追加
+      const newExcludedIds = [
+        ...state.excludedCardIds,
+        ...newCards.map((c) => c.id),
+      ];
+      return {
+        ...state,
+        playerHand: newPlayerHand,
+        selectedCardIds: [],
+        excludedCardIds: newExcludedIds,
+        phase: 'exchanging',
+      };
+    }
+
+    case 'SKIP_EXCHANGE': {
+      return {
+        ...state,
+        selectedCardIds: [],
+        phase: 'revealing',
+      };
+    }
+
+    case 'SET_ROLES': {
+      return {
+        ...state,
+        playerRole: action.payload.playerRole,
+        dealerRole: action.payload.dealerRole,
+        phase: 'result',
+      };
+    }
+
+    case 'UPDATE_SCORES': {
+      const { playerPoints, dealerPoints, result } = action.payload;
+      const roundResult: RoundHistory = {
+        round: state.round,
+        playerRole: state.playerRole!,
+        playerPoints,
+        ...(state.mode === 'battle' && {
+          dealerRole: state.dealerRole!,
+          dealerPoints,
+          result,
+        }),
+      };
+      return {
+        ...state,
+        playerScore: state.playerScore + playerPoints,
+        dealerScore: state.dealerScore + dealerPoints,
+        roundHistory: [...state.roundHistory, roundResult],
+      };
+    }
+
+    case 'NEXT_ROUND': {
+      if (state.round >= TOTAL_ROUNDS) {
+        return {
+          ...state,
+          phase: 'finished',
+        };
+      }
+      return {
+        ...state,
+        round: state.round + 1,
+        phase: 'dealing',
+        playerHand: [],
+        dealerHand: [],
+        selectedCardIds: [],
+        playerRole: null,
+        dealerRole: null,
+        excludedCardIds: [],
+      };
+    }
+
+    case 'FINISH_GAME': {
+      return {
+        ...state,
+        phase: 'finished',
+      };
+    }
+
+    case 'RESET_GAME': {
+      return initialGameState;
+    }
+
+    default:
+      return state;
+  }
+}
+
+/** GameContext の値の型 */
+interface GameContextValue {
+  state: GameState;
+  startGame: (mode: GameMode) => void;
+  selectCard: (cardId: number) => void;
+  exchangeCards: () => Promise<void>;
+  skipExchange: () => void;
+  nextRound: () => void;
+  finishGame: () => void;
+  resetGame: () => void;
+}
+
+/** GameContext */
+const GameContext = createContext<GameContextValue | null>(null);
+
+/** GameContext の Provider Props */
+interface GameProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * GameContext Provider
+ * ゲーム状態を管理し、アクションを提供する
+ */
+export function GameProvider({ children }: GameProviderProps) {
+  const [state, dispatch] = useReducer(gameReducer, initialGameState);
+
+  /**
+   * ゲーム開始
+   * 指定されたモードでゲームを開始し、カードを配布する
+   */
+  const startGame = useCallback((mode: GameMode) => {
+    dispatch({ type: 'START_GAME', payload: { mode } });
+
+    // カード配布
+    const playerHand = drawCards(HAND_SIZE, []);
+    const excludeForDealer = playerHand.map((c) => c.id);
+    const dealerHand =
+      mode === 'battle' ? drawCards(HAND_SIZE, excludeForDealer) : [];
+
+    dispatch({
+      type: 'SET_HANDS',
+      payload: { playerHand, dealerHand },
+    });
+  }, []);
+
+  /**
+   * カード選択/解除
+   * 指定されたカードIDの選択状態をトグルする
+   */
+  const selectCard = useCallback((cardId: number) => {
+    dispatch({ type: 'SELECT_CARD', payload: { cardId } });
+  }, []);
+
+  /**
+   * カード交換実行
+   * 選択されたカードを新しいカードと交換し、役を判定する
+   */
+  const exchangeCards = useCallback(async () => {
+    if (state.selectedCardIds.length === 0) {
+      // 選択なしの場合は交換スキップと同じ
+      dispatch({ type: 'SKIP_EXCHANGE' });
+    } else {
+      // 新しいカードを引く
+      const newCards = drawCards(state.selectedCardIds.length, state.excludedCardIds);
+
+      dispatch({
+        type: 'EXCHANGE_CARDS',
+        payload: {
+          newCards,
+          exchangedCardIds: state.selectedCardIds,
+        },
+      });
+    }
+
+    // 交換アニメーション用の遅延
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    // 現在の手札を取得（交換後の状態）
+    dispatch({ type: 'SET_PHASE', payload: { phase: 'revealing' } });
+  }, [state.selectedCardIds, state.excludedCardIds]);
+
+  /**
+   * 交換スキップ
+   * カードを交換せずに役判定に進む
+   */
+  const skipExchange = useCallback(() => {
+    dispatch({ type: 'SKIP_EXCHANGE' });
+  }, []);
+
+  /**
+   * 次のラウンドへ
+   * スコアを更新し、次のラウンドを開始する
+   */
+  const nextRound = useCallback(() => {
+    // 役を判定
+    const playerRole = calculateRole(state.playerHand);
+    const dealerRole =
+      state.mode === 'battle' ? calculateRole(state.dealerHand) : null;
+
+    dispatch({
+      type: 'SET_ROLES',
+      payload: { playerRole, dealerRole },
+    });
+
+    // スコア計算
+    let playerPoints = 0;
+    let dealerPoints = 0;
+    let result: 'win' | 'lose' | 'draw' | undefined;
+
+    if (state.mode === 'solo') {
+      playerPoints = playerRole.points;
+    } else if (state.mode === 'battle' && dealerRole) {
+      result = determineWinner(playerRole, dealerRole);
+      if (result === 'win') {
+        playerPoints = playerRole.points;
+        dealerPoints = -playerRole.points;
+      } else if (result === 'lose') {
+        playerPoints = -dealerRole.points;
+        dealerPoints = dealerRole.points;
+      }
+      // draw の場合は両方0
+    }
+
+    dispatch({
+      type: 'UPDATE_SCORES',
+      payload: { playerPoints, dealerPoints, result },
+    });
+
+    // 次のラウンドへ進む（または終了）
+    dispatch({ type: 'NEXT_ROUND' });
+
+    // 次のラウンドの場合はカードを配布
+    if (state.round < TOTAL_ROUNDS) {
+      setTimeout(() => {
+        const playerHand = drawCards(HAND_SIZE, []);
+        const excludeForDealer = playerHand.map((c) => c.id);
+        const dealerHand =
+          state.mode === 'battle'
+            ? drawCards(HAND_SIZE, excludeForDealer)
+            : [];
+
+        dispatch({
+          type: 'SET_HANDS',
+          payload: { playerHand, dealerHand },
+        });
+      }, 100);
+    }
+  }, [state.playerHand, state.dealerHand, state.mode, state.round]);
+
+  /**
+   * ゲーム終了
+   * ゲームを終了状態にする
+   */
+  const finishGame = useCallback(() => {
+    dispatch({ type: 'FINISH_GAME' });
+  }, []);
+
+  /**
+   * ゲームリセット
+   * ゲーム状態を初期状態に戻す
+   */
+  const resetGame = useCallback(() => {
+    dispatch({ type: 'RESET_GAME' });
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      state,
+      startGame,
+      selectCard,
+      exchangeCards,
+      skipExchange,
+      nextRound,
+      finishGame,
+      resetGame,
+    }),
+    [
+      state,
+      startGame,
+      selectCard,
+      exchangeCards,
+      skipExchange,
+      nextRound,
+      finishGame,
+      resetGame,
+    ]
+  );
+
+  return <GameContext.Provider value={value}>{children}</GameContext.Provider>;
+}
+
+/**
+ * GameContext を使用するカスタムフック
+ * Provider の外で使用された場合はエラーをスローする
+ */
+export function useGame(): GameContextValue {
+  const context = useContext(GameContext);
+  if (!context) {
+    throw new Error('useGame must be used within a GameProvider');
+  }
+  return context;
+}
+
+export { GameContext };

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -1,0 +1,158 @@
+// context/SettingsContext.tsx
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+  type ReactNode,
+} from 'react';
+
+import {
+  DEFAULT_SETTINGS,
+  STORAGE_KEY,
+  CURRENT_VERSION,
+  type SettingsData,
+  type StorageData,
+} from '../types';
+
+/** SettingsContext の値の型 */
+interface SettingsContextValue {
+  soundEnabled: boolean;
+  volume: number;
+  toggleSound: () => void;
+  setVolume: (value: number) => void;
+}
+
+/** SettingsContext */
+const SettingsContext = createContext<SettingsContextValue | null>(null);
+
+/** SettingsContext の Provider Props */
+interface SettingsProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * ローカルストレージから設定を読み込む
+ */
+function loadSettings(): SettingsData {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const data: StorageData = JSON.parse(stored);
+      if (data.version === CURRENT_VERSION && data.settings) {
+        return data.settings;
+      }
+    }
+  } catch (error) {
+    console.error('Failed to load settings from localStorage:', error);
+  }
+  return DEFAULT_SETTINGS;
+}
+
+/**
+ * ローカルストレージに設定を保存する
+ */
+function saveSettings(settings: SettingsData): void {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    let data: StorageData;
+
+    if (stored) {
+      data = JSON.parse(stored);
+      data.settings = settings;
+    } else {
+      data = {
+        settings,
+        stats: {
+          solo: { playCount: 0, highScore: 0, totalScore: 0 },
+          battle: { playCount: 0, wins: 0, losses: 0 },
+          roleAchievements: {},
+        },
+        version: CURRENT_VERSION,
+      };
+    }
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch (error) {
+    console.error('Failed to save settings to localStorage:', error);
+  }
+}
+
+/**
+ * SettingsContext Provider
+ * 効果音と音量の設定を管理する
+ */
+export function SettingsProvider({ children }: SettingsProviderProps) {
+  const [settings, setSettings] = useState<SettingsData>(DEFAULT_SETTINGS);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // 初回マウント時にローカルストレージから設定を読み込む
+  useEffect(() => {
+    const loadedSettings = loadSettings();
+    setSettings(loadedSettings);
+    setIsInitialized(true);
+  }, []);
+
+  // 設定変更時にローカルストレージに保存する
+  useEffect(() => {
+    if (isInitialized) {
+      saveSettings(settings);
+    }
+  }, [settings, isInitialized]);
+
+  /**
+   * 効果音のON/OFFを切り替える
+   */
+  const toggleSound = useCallback(() => {
+    setSettings((prev) => ({
+      ...prev,
+      soundEnabled: !prev.soundEnabled,
+    }));
+  }, []);
+
+  /**
+   * 音量を設定する
+   * @param value - 音量 (0-100)
+   */
+  const setVolume = useCallback((value: number) => {
+    // 0-100の範囲に制限
+    const clampedValue = Math.max(0, Math.min(100, value));
+    setSettings((prev) => ({
+      ...prev,
+      volume: clampedValue,
+    }));
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      soundEnabled: settings.soundEnabled,
+      volume: settings.volume,
+      toggleSound,
+      setVolume,
+    }),
+    [settings.soundEnabled, settings.volume, toggleSound, setVolume]
+  );
+
+  return (
+    <SettingsContext.Provider value={value}>
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+
+/**
+ * SettingsContext を使用するカスタムフック
+ * Provider の外で使用された場合はエラーをスローする
+ */
+export function useSettings(): SettingsContextValue {
+  const context = useContext(SettingsContext);
+  if (!context) {
+    throw new Error('useSettings must be used within a SettingsProvider');
+  }
+  return context;
+}
+
+export { SettingsContext };

--- a/src/context/StatsContext.tsx
+++ b/src/context/StatsContext.tsx
@@ -1,0 +1,201 @@
+// context/StatsContext.tsx
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+  type ReactNode,
+} from 'react';
+
+import {
+  DEFAULT_STATS,
+  STORAGE_KEY,
+  CURRENT_VERSION,
+  type StatsData,
+  type SoloStats,
+  type BattleStats,
+  type RoleAchievements,
+  type StorageData,
+} from '../types';
+import type { RoleType } from '../types';
+
+/** StatsContext の値の型 */
+interface StatsContextValue {
+  soloStats: SoloStats;
+  battleStats: BattleStats;
+  roleAchievements: RoleAchievements;
+  updateSoloStats: (score: number) => void;
+  updateBattleStats: (won: boolean) => void;
+  incrementRoleAchievement: (roleType: RoleType) => void;
+  resetStats: () => void;
+}
+
+/** StatsContext */
+const StatsContext = createContext<StatsContextValue | null>(null);
+
+/** StatsContext の Provider Props */
+interface StatsProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * ローカルストレージから統計を読み込む
+ */
+function loadStats(): StatsData {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const data: StorageData = JSON.parse(stored);
+      if (data.version === CURRENT_VERSION && data.stats) {
+        return data.stats;
+      }
+    }
+  } catch (error) {
+    console.error('Failed to load stats from localStorage:', error);
+  }
+  return DEFAULT_STATS;
+}
+
+/**
+ * ローカルストレージに統計を保存する
+ */
+function saveStats(stats: StatsData): void {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    let data: StorageData;
+
+    if (stored) {
+      data = JSON.parse(stored);
+      data.stats = stats;
+    } else {
+      data = {
+        settings: {
+          soundEnabled: true,
+          volume: 80,
+        },
+        stats,
+        version: CURRENT_VERSION,
+      };
+    }
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch (error) {
+    console.error('Failed to save stats to localStorage:', error);
+  }
+}
+
+/**
+ * StatsContext Provider
+ * ゲーム統計を管理する
+ */
+export function StatsProvider({ children }: StatsProviderProps) {
+  const [stats, setStats] = useState<StatsData>(DEFAULT_STATS);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // 初回マウント時にローカルストレージから統計を読み込む
+  useEffect(() => {
+    const loadedStats = loadStats();
+    setStats(loadedStats);
+    setIsInitialized(true);
+  }, []);
+
+  // 統計変更時にローカルストレージに保存する
+  useEffect(() => {
+    if (isInitialized) {
+      saveStats(stats);
+    }
+  }, [stats, isInitialized]);
+
+  /**
+   * ひとりモード統計を更新する
+   * @param score - 獲得スコア
+   */
+  const updateSoloStats = useCallback((score: number) => {
+    setStats((prev) => ({
+      ...prev,
+      solo: {
+        playCount: prev.solo.playCount + 1,
+        highScore: Math.max(prev.solo.highScore, score),
+        totalScore: prev.solo.totalScore + score,
+      },
+    }));
+  }, []);
+
+  /**
+   * 対戦モード統計を更新する
+   * @param won - 勝利したかどうか
+   */
+  const updateBattleStats = useCallback((won: boolean) => {
+    setStats((prev) => ({
+      ...prev,
+      battle: {
+        playCount: prev.battle.playCount + 1,
+        wins: won ? prev.battle.wins + 1 : prev.battle.wins,
+        losses: won ? prev.battle.losses : prev.battle.losses + 1,
+      },
+    }));
+  }, []);
+
+  /**
+   * 役達成回数を更新する
+   * @param roleType - 役の種類
+   */
+  const incrementRoleAchievement = useCallback((roleType: RoleType) => {
+    setStats((prev) => ({
+      ...prev,
+      roleAchievements: {
+        ...prev.roleAchievements,
+        [roleType]: (prev.roleAchievements[roleType] || 0) + 1,
+      },
+    }));
+  }, []);
+
+  /**
+   * 統計をリセットする
+   */
+  const resetStats = useCallback(() => {
+    setStats(DEFAULT_STATS);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      soloStats: stats.solo,
+      battleStats: stats.battle,
+      roleAchievements: stats.roleAchievements,
+      updateSoloStats,
+      updateBattleStats,
+      incrementRoleAchievement,
+      resetStats,
+    }),
+    [
+      stats.solo,
+      stats.battle,
+      stats.roleAchievements,
+      updateSoloStats,
+      updateBattleStats,
+      incrementRoleAchievement,
+      resetStats,
+    ]
+  );
+
+  return (
+    <StatsContext.Provider value={value}>{children}</StatsContext.Provider>
+  );
+}
+
+/**
+ * StatsContext を使用するカスタムフック
+ * Provider の外で使用された場合はエラーをスローする
+ */
+export function useStats(): StatsContextValue {
+  const context = useContext(StatsContext);
+  if (!context) {
+    throw new Error('useStats must be used within a StatsProvider');
+  }
+  return context;
+}
+
+export { StatsContext };

--- a/src/context/__tests__/GameContext.test.tsx
+++ b/src/context/__tests__/GameContext.test.tsx
@@ -1,0 +1,450 @@
+// context/__tests__/GameContext.test.tsx
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import {
+  GameProvider,
+  useGame,
+  initialGameState,
+  type GameState,
+} from '../GameContext';
+import * as deckModule from '../../utils/deck';
+import type { Card } from '../../types';
+
+/** テスト用のカード生成ヘルパー */
+function createTestCard(id: number, color: number, fur: number): Card {
+  return {
+    id,
+    image: `/images/image_${String(id).padStart(3, '0')}.jpg`,
+    color: color as any,
+    fur: fur as any,
+  };
+}
+
+/** テスト用の手札（5枚） */
+const mockPlayerHand: Card[] = [
+  createTestCard(0, 0, 1),  // 茶トラ、短毛
+  createTestCard(1, 0, 1),  // 茶トラ、短毛
+  createTestCard(2, 1, 1),  // 三毛、短毛
+  createTestCard(3, 2, 1),  // 白猫、短毛
+  createTestCard(4, 3, 1),  // 黒猫、短毛
+];
+
+/** テスト用のディーラー手札（5枚） */
+const mockDealerHand: Card[] = [
+  createTestCard(5, 4, 1),  // 茶白、短毛
+  createTestCard(6, 4, 1),  // 茶白、短毛
+  createTestCard(7, 5, 1),  // キジ白、短毛
+  createTestCard(8, 6, 1),  // キジトラ、短毛
+  createTestCard(9, 7, 1),  // 白黒、短毛
+];
+
+/** Wrapper コンポーネント */
+function wrapper({ children }: { children: ReactNode }) {
+  return <GameProvider>{children}</GameProvider>;
+}
+
+describe('GameContext', () => {
+  beforeEach(() => {
+    vi.spyOn(deckModule, 'drawCards');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('初期状態', () => {
+    it('初期状態が正しく設定されている', () => {
+      const { result } = renderHook(() => useGame(), { wrapper });
+
+      expect(result.current.state).toEqual(initialGameState);
+    });
+
+    it('初期状態のプロパティが正しい', () => {
+      const { result } = renderHook(() => useGame(), { wrapper });
+
+      expect(result.current.state.mode).toBe('solo');
+      expect(result.current.state.phase).toBe('dealing');
+      expect(result.current.state.round).toBe(1);
+      expect(result.current.state.playerHand).toEqual([]);
+      expect(result.current.state.dealerHand).toEqual([]);
+      expect(result.current.state.selectedCardIds).toEqual([]);
+      expect(result.current.state.playerRole).toBeNull();
+      expect(result.current.state.dealerRole).toBeNull();
+      expect(result.current.state.playerScore).toBe(0);
+      expect(result.current.state.dealerScore).toBe(0);
+      expect(result.current.state.roundHistory).toEqual([]);
+      expect(result.current.state.excludedCardIds).toEqual([]);
+    });
+  });
+
+  describe('startGame', () => {
+    it('ひとりモードでゲームを開始できる', () => {
+      vi.mocked(deckModule.drawCards).mockReturnValueOnce(mockPlayerHand);
+
+      const { result } = renderHook(() => useGame(), { wrapper });
+
+      act(() => {
+        result.current.startGame('solo');
+      });
+
+      expect(result.current.state.mode).toBe('solo');
+      expect(result.current.state.phase).toBe('selecting');
+      expect(result.current.state.round).toBe(1);
+      expect(result.current.state.playerHand).toEqual(mockPlayerHand);
+      expect(result.current.state.dealerHand).toEqual([]);
+    });
+
+    it('対戦モードでゲームを開始できる', () => {
+      vi.mocked(deckModule.drawCards)
+        .mockReturnValueOnce(mockPlayerHand)
+        .mockReturnValueOnce(mockDealerHand);
+
+      const { result } = renderHook(() => useGame(), { wrapper });
+
+      act(() => {
+        result.current.startGame('battle');
+      });
+
+      expect(result.current.state.mode).toBe('battle');
+      expect(result.current.state.phase).toBe('selecting');
+      expect(result.current.state.playerHand).toEqual(mockPlayerHand);
+      expect(result.current.state.dealerHand).toEqual(mockDealerHand);
+    });
+
+    it('ゲーム開始時に除外リストが設定される', () => {
+      vi.mocked(deckModule.drawCards)
+        .mockReturnValueOnce(mockPlayerHand)
+        .mockReturnValueOnce(mockDealerHand);
+
+      const { result } = renderHook(() => useGame(), { wrapper });
+
+      act(() => {
+        result.current.startGame('battle');
+      });
+
+      const expectedExcludedIds = [
+        ...mockPlayerHand.map((c) => c.id),
+        ...mockDealerHand.map((c) => c.id),
+      ];
+      expect(result.current.state.excludedCardIds).toEqual(expectedExcludedIds);
+    });
+  });
+
+  describe('selectCard', () => {
+    it('カードを選択できる', () => {
+      vi.mocked(deckModule.drawCards).mockReturnValueOnce(mockPlayerHand);
+
+      const { result } = renderHook(() => useGame(), { wrapper });
+
+      act(() => {
+        result.current.startGame('solo');
+      });
+
+      act(() => {
+        result.current.selectCard(0);
+      });
+
+      expect(result.current.state.selectedCardIds).toContain(0);
+    });
+
+    it('選択済みカードを解除できる', () => {
+      vi.mocked(deckModule.drawCards).mockReturnValueOnce(mockPlayerHand);
+
+      const { result } = renderHook(() => useGame(), { wrapper });
+
+      act(() => {
+        result.current.startGame('solo');
+      });
+
+      act(() => {
+        result.current.selectCard(0);
+      });
+
+      expect(result.current.state.selectedCardIds).toContain(0);
+
+      act(() => {
+        result.current.selectCard(0);
+      });
+
+      expect(result.current.state.selectedCardIds).not.toContain(0);
+    });
+
+    it('複数のカードを選択できる', () => {
+      vi.mocked(deckModule.drawCards).mockReturnValueOnce(mockPlayerHand);
+
+      const { result } = renderHook(() => useGame(), { wrapper });
+
+      act(() => {
+        result.current.startGame('solo');
+      });
+
+      act(() => {
+        result.current.selectCard(0);
+        result.current.selectCard(1);
+        result.current.selectCard(2);
+      });
+
+      expect(result.current.state.selectedCardIds).toEqual([0, 1, 2]);
+    });
+  });
+
+  describe('exchangeCards', () => {
+    it('選択したカードを交換できる', async () => {
+      const newCards: Card[] = [
+        createTestCard(10, 8, 1),
+        createTestCard(11, 9, 1),
+      ];
+
+      vi.mocked(deckModule.drawCards)
+        .mockReturnValueOnce(mockPlayerHand)
+        .mockReturnValueOnce(newCards);
+
+      const { result } = renderHook(() => useGame(), { wrapper });
+
+      act(() => {
+        result.current.startGame('solo');
+      });
+
+      act(() => {
+        result.current.selectCard(0);
+        result.current.selectCard(1);
+      });
+
+      await act(async () => {
+        await result.current.exchangeCards();
+      });
+
+      // 交換後のフェーズ
+      expect(result.current.state.phase).toBe('revealing');
+
+      // 選択がクリアされている
+      expect(result.current.state.selectedCardIds).toEqual([]);
+    });
+
+    it('カードを選択していない場合はスキップと同じ動作', async () => {
+      vi.mocked(deckModule.drawCards).mockReturnValueOnce(mockPlayerHand);
+
+      const { result } = renderHook(() => useGame(), { wrapper });
+
+      act(() => {
+        result.current.startGame('solo');
+      });
+
+      await act(async () => {
+        await result.current.exchangeCards();
+      });
+
+      expect(result.current.state.phase).toBe('revealing');
+    });
+  });
+
+  describe('skipExchange', () => {
+    it('交換をスキップできる', () => {
+      vi.mocked(deckModule.drawCards).mockReturnValueOnce(mockPlayerHand);
+
+      const { result } = renderHook(() => useGame(), { wrapper });
+
+      act(() => {
+        result.current.startGame('solo');
+      });
+
+      act(() => {
+        result.current.selectCard(0);
+      });
+
+      act(() => {
+        result.current.skipExchange();
+      });
+
+      expect(result.current.state.phase).toBe('revealing');
+      expect(result.current.state.selectedCardIds).toEqual([]);
+    });
+  });
+
+  describe('nextRound', () => {
+    it('次のラウンドに進める（ひとりモード）', async () => {
+      vi.mocked(deckModule.drawCards)
+        .mockReturnValueOnce(mockPlayerHand)
+        .mockReturnValueOnce(mockPlayerHand);  // 次のラウンド用
+
+      const { result } = renderHook(() => useGame(), { wrapper });
+
+      act(() => {
+        result.current.startGame('solo');
+      });
+
+      act(() => {
+        result.current.skipExchange();
+      });
+
+      act(() => {
+        result.current.nextRound();
+      });
+
+      // ラウンドが進む
+      await waitFor(() => {
+        expect(result.current.state.round).toBe(2);
+      });
+
+      // スコアが更新される
+      expect(result.current.state.roundHistory.length).toBe(1);
+    });
+
+    it('5ラウンド目でゲーム終了', async () => {
+      vi.mocked(deckModule.drawCards).mockReturnValue(mockPlayerHand);
+
+      const { result } = renderHook(() => useGame(), { wrapper });
+
+      act(() => {
+        result.current.startGame('solo');
+      });
+
+      // 5ラウンドプレイ
+      for (let i = 0; i < 5; i++) {
+        act(() => {
+          result.current.skipExchange();
+        });
+        act(() => {
+          result.current.nextRound();
+        });
+
+        // 最終ラウンド以外は次のカード配布を待つ
+        if (i < 4) {
+          await waitFor(() => {
+            expect(result.current.state.phase).toBe('selecting');
+          });
+        }
+      }
+
+      expect(result.current.state.phase).toBe('finished');
+    });
+
+    it('対戦モードで勝敗が判定される', () => {
+      // プレイヤー: 茶トラ2枚（ワンペア: 5pt）
+      const playerHandWithPair: Card[] = [
+        createTestCard(0, 0, 1),
+        createTestCard(1, 0, 1),
+        createTestCard(2, 1, 1),
+        createTestCard(3, 2, 1),
+        createTestCard(4, 3, 1),
+      ];
+
+      // ディーラー: ノーペア（0pt）
+      const dealerHandNoPair: Card[] = [
+        createTestCard(5, 4, 1),
+        createTestCard(6, 5, 1),
+        createTestCard(7, 6, 1),
+        createTestCard(8, 7, 1),
+        createTestCard(9, 8, 1),
+      ];
+
+      vi.mocked(deckModule.drawCards)
+        .mockReturnValueOnce(playerHandWithPair)
+        .mockReturnValueOnce(dealerHandNoPair)
+        .mockReturnValue(playerHandWithPair);
+
+      const { result } = renderHook(() => useGame(), { wrapper });
+
+      act(() => {
+        result.current.startGame('battle');
+      });
+
+      act(() => {
+        result.current.skipExchange();
+      });
+
+      act(() => {
+        result.current.nextRound();
+      });
+
+      // ラウンド履歴に結果が記録される
+      expect(result.current.state.roundHistory.length).toBe(1);
+      expect(result.current.state.roundHistory[0].result).toBe('win');
+    });
+  });
+
+  describe('finishGame', () => {
+    it('ゲームを終了状態にできる', () => {
+      vi.mocked(deckModule.drawCards).mockReturnValueOnce(mockPlayerHand);
+
+      const { result } = renderHook(() => useGame(), { wrapper });
+
+      act(() => {
+        result.current.startGame('solo');
+      });
+
+      act(() => {
+        result.current.finishGame();
+      });
+
+      expect(result.current.state.phase).toBe('finished');
+    });
+  });
+
+  describe('resetGame', () => {
+    it('ゲームを初期状態にリセットできる', () => {
+      vi.mocked(deckModule.drawCards).mockReturnValueOnce(mockPlayerHand);
+
+      const { result } = renderHook(() => useGame(), { wrapper });
+
+      act(() => {
+        result.current.startGame('solo');
+      });
+
+      act(() => {
+        result.current.resetGame();
+      });
+
+      expect(result.current.state).toEqual(initialGameState);
+    });
+  });
+
+  describe('Provider外での使用', () => {
+    it('Provider外で使用するとエラーがスローされる', () => {
+      // コンソールエラーを抑制
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => {
+        renderHook(() => useGame());
+      }).toThrow('useGame must be used within a GameProvider');
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('状態遷移', () => {
+    it('dealing -> selecting -> revealing -> result -> selecting の遷移', async () => {
+      vi.mocked(deckModule.drawCards).mockReturnValue(mockPlayerHand);
+
+      const { result } = renderHook(() => useGame(), { wrapper });
+
+      // 初期: dealing
+      expect(result.current.state.phase).toBe('dealing');
+
+      // ゲーム開始: selecting
+      act(() => {
+        result.current.startGame('solo');
+      });
+      expect(result.current.state.phase).toBe('selecting');
+
+      // 交換スキップ: revealing
+      act(() => {
+        result.current.skipExchange();
+      });
+      expect(result.current.state.phase).toBe('revealing');
+
+      // 次のラウンド実行後、結果表示を経て次のラウンドへ
+      act(() => {
+        result.current.nextRound();
+      });
+
+      // 次のラウンドのカードが配布されるまで待機
+      await waitFor(() => {
+        expect(result.current.state.phase).toBe('selecting');
+        expect(result.current.state.round).toBe(2);
+      });
+    });
+  });
+});

--- a/src/context/__tests__/SettingsContext.test.tsx
+++ b/src/context/__tests__/SettingsContext.test.tsx
@@ -1,0 +1,242 @@
+// context/__tests__/SettingsContext.test.tsx
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { SettingsProvider, useSettings } from '../SettingsContext';
+import { STORAGE_KEY, CURRENT_VERSION, DEFAULT_SETTINGS } from '../../types';
+
+/** Wrapper コンポーネント */
+function wrapper({ children }: { children: ReactNode }) {
+  return <SettingsProvider>{children}</SettingsProvider>;
+}
+
+describe('SettingsContext', () => {
+  beforeEach(() => {
+    // ローカルストレージをクリア
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('初期状態', () => {
+    it('デフォルト設定が正しく読み込まれる', () => {
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      expect(result.current.soundEnabled).toBe(true);
+      expect(result.current.volume).toBe(80);
+    });
+
+    it('ローカルストレージから設定を読み込む', () => {
+      const savedData = {
+        settings: {
+          soundEnabled: false,
+          volume: 50,
+        },
+        stats: {
+          solo: { playCount: 0, highScore: 0, totalScore: 0 },
+          battle: { playCount: 0, wins: 0, losses: 0 },
+          roleAchievements: {},
+        },
+        version: CURRENT_VERSION,
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(savedData));
+
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      // useEffectを実行
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(result.current.soundEnabled).toBe(false);
+      expect(result.current.volume).toBe(50);
+    });
+
+    it('バージョンが異なる場合はデフォルト設定を使用', () => {
+      const savedData = {
+        settings: {
+          soundEnabled: false,
+          volume: 50,
+        },
+        stats: {
+          solo: { playCount: 0, highScore: 0, totalScore: 0 },
+          battle: { playCount: 0, wins: 0, losses: 0 },
+          roleAchievements: {},
+        },
+        version: 999,  // 無効なバージョン
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(savedData));
+
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(result.current.soundEnabled).toBe(DEFAULT_SETTINGS.soundEnabled);
+      expect(result.current.volume).toBe(DEFAULT_SETTINGS.volume);
+    });
+
+    it('無効なJSONの場合はデフォルト設定を使用', () => {
+      localStorage.setItem(STORAGE_KEY, 'invalid json');
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(result.current.soundEnabled).toBe(DEFAULT_SETTINGS.soundEnabled);
+      expect(result.current.volume).toBe(DEFAULT_SETTINGS.volume);
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('toggleSound', () => {
+    it('効果音のON/OFFを切り替えられる', () => {
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      expect(result.current.soundEnabled).toBe(true);
+
+      act(() => {
+        result.current.toggleSound();
+      });
+
+      expect(result.current.soundEnabled).toBe(false);
+
+      act(() => {
+        result.current.toggleSound();
+      });
+
+      expect(result.current.soundEnabled).toBe(true);
+    });
+
+    it('切り替えがローカルストレージに保存される', () => {
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      act(() => {
+        result.current.toggleSound();
+      });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      expect(saved.settings.soundEnabled).toBe(false);
+    });
+  });
+
+  describe('setVolume', () => {
+    it('音量を設定できる', () => {
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      act(() => {
+        result.current.setVolume(50);
+      });
+
+      expect(result.current.volume).toBe(50);
+    });
+
+    it('0未満の値は0にクランプされる', () => {
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      act(() => {
+        result.current.setVolume(-10);
+      });
+
+      expect(result.current.volume).toBe(0);
+    });
+
+    it('100を超える値は100にクランプされる', () => {
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      act(() => {
+        result.current.setVolume(150);
+      });
+
+      expect(result.current.volume).toBe(100);
+    });
+
+    it('音量がローカルストレージに保存される', () => {
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      act(() => {
+        result.current.setVolume(30);
+      });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      expect(saved.settings.volume).toBe(30);
+    });
+  });
+
+  describe('Provider外での使用', () => {
+    it('Provider外で使用するとエラーがスローされる', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => {
+        renderHook(() => useSettings());
+      }).toThrow('useSettings must be used within a SettingsProvider');
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('ローカルストレージへの保存', () => {
+    it('既存データがある場合は設定のみ更新される', () => {
+      const existingData = {
+        settings: {
+          soundEnabled: true,
+          volume: 80,
+        },
+        stats: {
+          solo: { playCount: 10, highScore: 100, totalScore: 500 },
+          battle: { playCount: 5, wins: 3, losses: 2 },
+          roleAchievements: { flush: 1 },
+        },
+        version: CURRENT_VERSION,
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(existingData));
+
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      act(() => {
+        result.current.setVolume(50);
+      });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      // 設定は更新される
+      expect(saved.settings.volume).toBe(50);
+      // 統計は保持される
+      expect(saved.stats.solo.playCount).toBe(10);
+      expect(saved.stats.roleAchievements.flush).toBe(1);
+    });
+  });
+});

--- a/src/context/__tests__/StatsContext.test.tsx
+++ b/src/context/__tests__/StatsContext.test.tsx
@@ -1,0 +1,348 @@
+// context/__tests__/StatsContext.test.tsx
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { StatsProvider, useStats } from '../StatsContext';
+import { STORAGE_KEY, CURRENT_VERSION, DEFAULT_STATS } from '../../types';
+
+/** Wrapper コンポーネント */
+function wrapper({ children }: { children: ReactNode }) {
+  return <StatsProvider>{children}</StatsProvider>;
+}
+
+describe('StatsContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('初期状態', () => {
+    it('デフォルト統計が正しく読み込まれる', () => {
+      const { result } = renderHook(() => useStats(), { wrapper });
+
+      expect(result.current.soloStats).toEqual(DEFAULT_STATS.solo);
+      expect(result.current.battleStats).toEqual(DEFAULT_STATS.battle);
+      expect(result.current.roleAchievements).toEqual(DEFAULT_STATS.roleAchievements);
+    });
+
+    it('ローカルストレージから統計を読み込む', () => {
+      const savedData = {
+        settings: {
+          soundEnabled: true,
+          volume: 80,
+        },
+        stats: {
+          solo: { playCount: 10, highScore: 150, totalScore: 800 },
+          battle: { playCount: 5, wins: 3, losses: 2 },
+          roleAchievements: { flush: 2, fourColor: 5 },
+        },
+        version: CURRENT_VERSION,
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(savedData));
+
+      const { result } = renderHook(() => useStats(), { wrapper });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(result.current.soloStats.playCount).toBe(10);
+      expect(result.current.soloStats.highScore).toBe(150);
+      expect(result.current.battleStats.wins).toBe(3);
+      expect(result.current.roleAchievements.flush).toBe(2);
+    });
+
+    it('バージョンが異なる場合はデフォルト統計を使用', () => {
+      const savedData = {
+        settings: {
+          soundEnabled: true,
+          volume: 80,
+        },
+        stats: {
+          solo: { playCount: 10, highScore: 150, totalScore: 800 },
+          battle: { playCount: 5, wins: 3, losses: 2 },
+          roleAchievements: {},
+        },
+        version: 999,
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(savedData));
+
+      const { result } = renderHook(() => useStats(), { wrapper });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(result.current.soloStats).toEqual(DEFAULT_STATS.solo);
+    });
+  });
+
+  describe('updateSoloStats', () => {
+    it('ひとりモード統計を更新できる', () => {
+      const { result } = renderHook(() => useStats(), { wrapper });
+
+      act(() => {
+        result.current.updateSoloStats(50);
+      });
+
+      expect(result.current.soloStats.playCount).toBe(1);
+      expect(result.current.soloStats.highScore).toBe(50);
+      expect(result.current.soloStats.totalScore).toBe(50);
+    });
+
+    it('複数回プレイで統計が累積される', () => {
+      const { result } = renderHook(() => useStats(), { wrapper });
+
+      act(() => {
+        result.current.updateSoloStats(50);
+      });
+
+      act(() => {
+        result.current.updateSoloStats(100);
+      });
+
+      act(() => {
+        result.current.updateSoloStats(30);
+      });
+
+      expect(result.current.soloStats.playCount).toBe(3);
+      expect(result.current.soloStats.highScore).toBe(100);
+      expect(result.current.soloStats.totalScore).toBe(180);
+    });
+
+    it('ハイスコアより低いスコアではハイスコアは更新されない', () => {
+      const { result } = renderHook(() => useStats(), { wrapper });
+
+      act(() => {
+        result.current.updateSoloStats(100);
+      });
+
+      act(() => {
+        result.current.updateSoloStats(50);
+      });
+
+      expect(result.current.soloStats.highScore).toBe(100);
+    });
+
+    it('統計がローカルストレージに保存される', () => {
+      const { result } = renderHook(() => useStats(), { wrapper });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      act(() => {
+        result.current.updateSoloStats(75);
+      });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      expect(saved.stats.solo.playCount).toBe(1);
+      expect(saved.stats.solo.highScore).toBe(75);
+    });
+  });
+
+  describe('updateBattleStats', () => {
+    it('勝利を記録できる', () => {
+      const { result } = renderHook(() => useStats(), { wrapper });
+
+      act(() => {
+        result.current.updateBattleStats(true);
+      });
+
+      expect(result.current.battleStats.playCount).toBe(1);
+      expect(result.current.battleStats.wins).toBe(1);
+      expect(result.current.battleStats.losses).toBe(0);
+    });
+
+    it('敗北を記録できる', () => {
+      const { result } = renderHook(() => useStats(), { wrapper });
+
+      act(() => {
+        result.current.updateBattleStats(false);
+      });
+
+      expect(result.current.battleStats.playCount).toBe(1);
+      expect(result.current.battleStats.wins).toBe(0);
+      expect(result.current.battleStats.losses).toBe(1);
+    });
+
+    it('複数回の対戦で統計が累積される', () => {
+      const { result } = renderHook(() => useStats(), { wrapper });
+
+      act(() => {
+        result.current.updateBattleStats(true);  // 勝利
+      });
+
+      act(() => {
+        result.current.updateBattleStats(true);  // 勝利
+      });
+
+      act(() => {
+        result.current.updateBattleStats(false); // 敗北
+      });
+
+      expect(result.current.battleStats.playCount).toBe(3);
+      expect(result.current.battleStats.wins).toBe(2);
+      expect(result.current.battleStats.losses).toBe(1);
+    });
+  });
+
+  describe('incrementRoleAchievement', () => {
+    it('役達成回数を記録できる', () => {
+      const { result } = renderHook(() => useStats(), { wrapper });
+
+      act(() => {
+        result.current.incrementRoleAchievement('flush');
+      });
+
+      expect(result.current.roleAchievements.flush).toBe(1);
+    });
+
+    it('同じ役の達成回数が累積される', () => {
+      const { result } = renderHook(() => useStats(), { wrapper });
+
+      act(() => {
+        result.current.incrementRoleAchievement('fourColor');
+      });
+
+      act(() => {
+        result.current.incrementRoleAchievement('fourColor');
+      });
+
+      act(() => {
+        result.current.incrementRoleAchievement('fourColor');
+      });
+
+      expect(result.current.roleAchievements.fourColor).toBe(3);
+    });
+
+    it('異なる役を記録できる', () => {
+      const { result } = renderHook(() => useStats(), { wrapper });
+
+      act(() => {
+        result.current.incrementRoleAchievement('flush');
+      });
+
+      act(() => {
+        result.current.incrementRoleAchievement('fourColor');
+      });
+
+      act(() => {
+        result.current.incrementRoleAchievement('onePair');
+      });
+
+      expect(result.current.roleAchievements.flush).toBe(1);
+      expect(result.current.roleAchievements.fourColor).toBe(1);
+      expect(result.current.roleAchievements.onePair).toBe(1);
+    });
+  });
+
+  describe('resetStats', () => {
+    it('統計をリセットできる', () => {
+      const { result } = renderHook(() => useStats(), { wrapper });
+
+      // 統計を追加
+      act(() => {
+        result.current.updateSoloStats(100);
+        result.current.updateBattleStats(true);
+        result.current.incrementRoleAchievement('flush');
+      });
+
+      // リセット
+      act(() => {
+        result.current.resetStats();
+      });
+
+      expect(result.current.soloStats).toEqual(DEFAULT_STATS.solo);
+      expect(result.current.battleStats).toEqual(DEFAULT_STATS.battle);
+      expect(result.current.roleAchievements).toEqual(DEFAULT_STATS.roleAchievements);
+    });
+
+    it('リセットがローカルストレージに保存される', () => {
+      const { result } = renderHook(() => useStats(), { wrapper });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      act(() => {
+        result.current.updateSoloStats(100);
+      });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      act(() => {
+        result.current.resetStats();
+      });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      expect(saved.stats.solo.playCount).toBe(0);
+    });
+  });
+
+  describe('Provider外での使用', () => {
+    it('Provider外で使用するとエラーがスローされる', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => {
+        renderHook(() => useStats());
+      }).toThrow('useStats must be used within a StatsProvider');
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('ローカルストレージへの保存', () => {
+    it('既存データがある場合は統計のみ更新される', () => {
+      const existingData = {
+        settings: {
+          soundEnabled: false,
+          volume: 30,
+        },
+        stats: {
+          solo: { playCount: 0, highScore: 0, totalScore: 0 },
+          battle: { playCount: 0, wins: 0, losses: 0 },
+          roleAchievements: {},
+        },
+        version: CURRENT_VERSION,
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(existingData));
+
+      const { result } = renderHook(() => useStats(), { wrapper });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      act(() => {
+        result.current.updateSoloStats(50);
+      });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      // 統計は更新される
+      expect(saved.stats.solo.playCount).toBe(1);
+      // 設定は保持される
+      expect(saved.settings.soundEnabled).toBe(false);
+      expect(saved.settings.volume).toBe(30);
+    });
+  });
+});

--- a/src/context/__tests__/index.test.ts
+++ b/src/context/__tests__/index.test.ts
@@ -1,0 +1,72 @@
+// context/__tests__/index.test.ts
+
+import { describe, it, expect } from 'vitest';
+import {
+  GameContext,
+  GameProvider,
+  useGame,
+  initialGameState,
+  SettingsContext,
+  SettingsProvider,
+  useSettings,
+  StatsContext,
+  StatsProvider,
+  useStats,
+} from '../index';
+
+describe('context/index.ts exports', () => {
+  describe('GameContext exports', () => {
+    it('GameContext がエクスポートされている', () => {
+      expect(GameContext).toBeDefined();
+    });
+
+    it('GameProvider がエクスポートされている', () => {
+      expect(GameProvider).toBeDefined();
+      expect(typeof GameProvider).toBe('function');
+    });
+
+    it('useGame がエクスポートされている', () => {
+      expect(useGame).toBeDefined();
+      expect(typeof useGame).toBe('function');
+    });
+
+    it('initialGameState がエクスポートされている', () => {
+      expect(initialGameState).toBeDefined();
+      expect(initialGameState.mode).toBe('solo');
+      expect(initialGameState.phase).toBe('dealing');
+      expect(initialGameState.round).toBe(1);
+    });
+  });
+
+  describe('SettingsContext exports', () => {
+    it('SettingsContext がエクスポートされている', () => {
+      expect(SettingsContext).toBeDefined();
+    });
+
+    it('SettingsProvider がエクスポートされている', () => {
+      expect(SettingsProvider).toBeDefined();
+      expect(typeof SettingsProvider).toBe('function');
+    });
+
+    it('useSettings がエクスポートされている', () => {
+      expect(useSettings).toBeDefined();
+      expect(typeof useSettings).toBe('function');
+    });
+  });
+
+  describe('StatsContext exports', () => {
+    it('StatsContext がエクスポートされている', () => {
+      expect(StatsContext).toBeDefined();
+    });
+
+    it('StatsProvider がエクスポートされている', () => {
+      expect(StatsProvider).toBeDefined();
+      expect(typeof StatsProvider).toBe('function');
+    });
+
+    it('useStats がエクスポートされている', () => {
+      expect(useStats).toBeDefined();
+      expect(typeof useStats).toBe('function');
+    });
+  });
+});

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,0 +1,11 @@
+// context/index.ts
+
+// GameContext
+export { GameContext, GameProvider, useGame, initialGameState } from './GameContext';
+export type { GameState } from './GameContext';
+
+// SettingsContext
+export { SettingsContext, SettingsProvider, useSettings } from './SettingsContext';
+
+// StatsContext
+export { StatsContext, StatsProvider, useStats } from './StatsContext';


### PR DESCRIPTION
## Summary

- ゲーム状態、設定、統計を管理する3つのReact Contextを実装
- GameContextで型の不整合を修正（selectedCardIds, excludedCardIdsをnumber[]に統一）
- 各Contextに対するユニットテストを追加（カバレッジ96%以上）

## Changes

- `src/context/GameContext.tsx`: ゲーム状態管理Context（mode, phase, round, hands, scores）
  - startGame, selectCard, exchangeCards, skipExchange, nextRound, finishGame, resetGame アクション
- `src/context/SettingsContext.tsx`: 設定管理Context（soundEnabled, volume）
  - LocalStorageへの永続化
- `src/context/StatsContext.tsx`: 統計管理Context（solo/battle stats, role achievements）
  - LocalStorageへの永続化
- `src/context/index.ts`: エクスポート用インデックスファイル
- `src/context/__tests__/`: 各Contextのテストファイル

## Code Review Results

### 指摘事項と修正内容

| # | 指摘事項 | 対応内容 | 対応状況 |
|---|---------|---------|---------|
| 1 | selectedCardIdsがstring[]だった | number[]に修正 | OK |
| 2 | excludedCardIdsがstring[]だった | number[]に修正 | OK |

## Test Results

- テスト実行結果: All tests passed (57/57)
- カバレッジ: 96.61%

## Related Issues

Closes #10

## Checklist

- [x] コードレビュー実施済み
- [x] テスト追加・更新済み