### PR TITLE
Implement TitleScreen component (#9)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,66 @@
+import { useState, useCallback } from 'react';
+import { TitleScreen } from './pages';
 import './App.css';
 
+/** Application screen type */
+type AppScreen = 'title' | 'game' | 'battle' | 'result';
+
 function App() {
-  return (
-    <div className="app">
-      <h1>にゃんポーカー</h1>
-      <p>猫カードで役を揃えるポーカーゲーム</p>
-    </div>
-  );
+  const [currentScreen, setCurrentScreen] = useState<AppScreen>('title');
+
+  // Screen transition handlers
+  const handleStartSolo = useCallback(() => {
+    setCurrentScreen('game');
+  }, []);
+
+  const handleStartBattle = useCallback(() => {
+    setCurrentScreen('battle');
+  }, []);
+
+  // Modal handlers (placeholder - will be implemented with modals)
+  const handleShowRules = useCallback(() => {
+    // TODO: Implement rules modal
+    console.log('Show rules modal');
+  }, []);
+
+  const handleShowStats = useCallback(() => {
+    // TODO: Implement stats modal
+    console.log('Show stats modal');
+  }, []);
+
+  const handleShowSettings = useCallback(() => {
+    // TODO: Implement settings modal
+    console.log('Show settings modal');
+  }, []);
+
+  // Render current screen
+  const renderScreen = () => {
+    switch (currentScreen) {
+      case 'title':
+        return (
+          <TitleScreen
+            onStartSolo={handleStartSolo}
+            onStartBattle={handleStartBattle}
+            onShowRules={handleShowRules}
+            onShowStats={handleShowStats}
+            onShowSettings={handleShowSettings}
+          />
+        );
+      case 'game':
+        // TODO: Implement GameScreen
+        return <div className="app">ゲーム画面（実装予定）</div>;
+      case 'battle':
+        // TODO: Implement BattleScreen
+        return <div className="app">対戦画面（実装予定）</div>;
+      case 'result':
+        // TODO: Integrate ResultScreen
+        return <div className="app">結果画面（実装予定）</div>;
+      default:
+        return null;
+    }
+  };
+
+  return <>{renderScreen()}</>;
 }
 
 export default App;

--- a/src/pages/TitleScreen.module.css
+++ b/src/pages/TitleScreen.module.css
@@ -1,0 +1,218 @@
+/* TitleScreen Styles */
+
+.titleScreen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: var(--space-5, 20px);
+  background: linear-gradient(180deg, var(--color-bg, #2d2a26) 0%, var(--color-bg-light, #3d3a35) 100%);
+  animation: fadeIn 0.4s ease-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.titleContainer {
+  text-align: center;
+  max-width: 400px;
+  width: 100%;
+}
+
+/* Title Logo */
+.titleLogo {
+  margin-bottom: var(--space-5, 20px);
+}
+
+.titleText {
+  font-size: var(--font-size-2xl, 32px);
+  color: var(--color-primary, #d4a574);
+  text-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  letter-spacing: 4px;
+  position: relative;
+  display: inline-block;
+  line-height: var(--line-height-tight, 1.3);
+  white-space: nowrap;
+  margin: 0;
+}
+
+/* Left cat ear */
+.titleText::before {
+  content: '';
+  position: absolute;
+  top: -20px;
+  left: -10px;
+  width: 0;
+  height: 0;
+  border-left: 12px solid transparent;
+  border-right: 12px solid transparent;
+  border-bottom: 20px solid var(--color-primary, #d4a574);
+  transform: rotate(-15deg);
+}
+
+/* Right cat ear */
+.titleText::after {
+  content: '';
+  position: absolute;
+  top: -20px;
+  right: -10px;
+  width: 0;
+  height: 0;
+  border-left: 12px solid transparent;
+  border-right: 12px solid transparent;
+  border-bottom: 20px solid var(--color-primary, #d4a574);
+  transform: rotate(15deg);
+}
+
+/* Subtitle */
+.titleSubtitle {
+  font-size: var(--font-size-base, 14px);
+  color: var(--color-text-muted, #a89f94);
+  margin-bottom: var(--space-10, 40px);
+  line-height: var(--line-height-normal, 1.5);
+}
+
+/* Decorative Cards */
+.titleCats {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-4, 16px);
+  margin-bottom: var(--space-12, 48px);
+}
+
+.titleCatCard {
+  width: 80px;
+  height: 107px;
+  border-radius: var(--radius-md, 8px);
+  overflow: hidden;
+  box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.3));
+  transform: rotate(var(--rotation));
+  transition: transform var(--transition-normal, 0.3s);
+}
+
+.titleCatCard:hover {
+  transform: rotate(0deg) scale(1.1);
+}
+
+.titleCatCard img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* Menu Buttons */
+.titleMenu {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4, 16px);
+  width: 100%;
+  max-width: 280px;
+  margin: 0 auto;
+}
+
+/* Footer Buttons */
+.titleFooter {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-5, 20px);
+  margin-top: var(--space-10, 40px);
+}
+
+/* Responsive - Tablet (768px+) */
+@media (min-width: 768px) {
+  .titleText {
+    font-size: var(--font-size-2xl, 32px);
+  }
+}
+
+/* Responsive - Desktop (1024px+) */
+@media (min-width: 1024px) {
+  .titleText {
+    font-size: var(--font-size-3xl, 48px);
+  }
+
+  .titleText::before,
+  .titleText::after {
+    top: -24px;
+    border-left-width: 14px;
+    border-right-width: 14px;
+    border-bottom-width: 24px;
+  }
+
+  .titleText::before {
+    left: -12px;
+  }
+
+  .titleText::after {
+    right: -12px;
+  }
+}
+
+/* Responsive - Mobile (max-width: 767px) */
+@media (max-width: 767px) {
+  .titleText {
+    font-size: var(--font-size-xl, 24px);
+    letter-spacing: 2px;
+  }
+
+  .titleText::before,
+  .titleText::after {
+    top: -14px;
+    border-left-width: 8px;
+    border-right-width: 8px;
+    border-bottom-width: 14px;
+  }
+
+  .titleText::before {
+    left: -6px;
+  }
+
+  .titleText::after {
+    right: -6px;
+  }
+
+  .titleCatCard {
+    width: 60px;
+    height: 80px;
+  }
+
+  .titleFooter {
+    flex-wrap: wrap;
+    gap: var(--space-3, 12px);
+  }
+}
+
+/* Responsive - Very small screens (max-width: 400px) */
+@media (max-width: 400px) {
+  .titleFooter {
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
+/* Landscape mobile */
+@media (orientation: landscape) and (max-height: 500px) {
+  .titleContainer {
+    padding-top: var(--space-2, 8px);
+  }
+
+  .titleCats {
+    margin-bottom: var(--space-4, 16px);
+  }
+
+  .titleMenu {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+    max-width: 100%;
+  }
+}

--- a/src/pages/TitleScreen.tsx
+++ b/src/pages/TitleScreen.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { Button } from '../components/common/Button';
+import styles from './TitleScreen.module.css';
+
+/** Images for decorative cards */
+const DECORATIVE_CARD_IMAGES = [
+  '/images/image_016.jpg', // 三毛の長毛猫
+  '/images/image_028.jpg', // サビの短毛猫
+  '/images/image_073.jpg', // 黒猫の長毛猫
+  '/images/image_023.jpg', // 白猫の長毛猫
+];
+
+/** Rotation angles for decorative cards */
+const CARD_ROTATIONS = [-12, -4, 4, 12];
+
+export interface TitleScreenProps {
+  /** Callback when starting solo mode */
+  onStartSolo: () => void;
+  /** Callback when starting battle mode */
+  onStartBattle: () => void;
+  /** Callback when rules button is clicked */
+  onShowRules: () => void;
+  /** Callback when stats button is clicked */
+  onShowStats: () => void;
+  /** Callback when settings button is clicked */
+  onShowSettings: () => void;
+}
+
+/**
+ * TitleScreen component
+ *
+ * Displays the game's title screen with:
+ * - Title logo with cat ears
+ * - Subtitle
+ * - Decorative cat cards with rotation animation
+ * - Game mode selection buttons (Solo / Battle)
+ * - Footer buttons (Rules / Stats / Settings)
+ */
+export const TitleScreen: React.FC<TitleScreenProps> = ({
+  onStartSolo,
+  onStartBattle,
+  onShowRules,
+  onShowStats,
+  onShowSettings,
+}) => {
+  return (
+    <div className={styles.titleScreen}>
+      <div className={styles.titleContainer}>
+        {/* Title Logo with Cat Ears */}
+        <div className={styles.titleLogo}>
+          <h1 className={styles.titleText}>にゃんポーカー</h1>
+        </div>
+
+        {/* Subtitle */}
+        <p className={styles.titleSubtitle}>猫カードで役を揃えるポーカーゲーム</p>
+
+        {/* Decorative Cards */}
+        <div className={styles.titleCats}>
+          {DECORATIVE_CARD_IMAGES.map((imagePath, index) => (
+            <div
+              key={imagePath}
+              className={styles.titleCatCard}
+              style={{ '--rotation': `${CARD_ROTATIONS[index]}deg` } as React.CSSProperties}
+            >
+              <img src={imagePath} alt={`装飾用猫カード ${index + 1}`} />
+            </div>
+          ))}
+        </div>
+
+        {/* Main Menu Buttons */}
+        <div className={styles.titleMenu}>
+          <Button
+            variant="primary"
+            size="lg"
+            onClick={onStartSolo}
+            aria-label="ひとりで遊ぶモードを開始"
+          >
+            ひとりで遊ぶ
+          </Button>
+          <Button
+            variant="secondary"
+            size="lg"
+            onClick={onStartBattle}
+            aria-label="対戦モードを開始"
+          >
+            対戦モード
+          </Button>
+        </div>
+
+        {/* Footer Buttons */}
+        <div className={styles.titleFooter}>
+          <Button
+            variant="footer"
+            icon="?"
+            label="遊び方"
+            onClick={onShowRules}
+            aria-label="遊び方を見る"
+          />
+          <Button
+            variant="footer"
+            icon={<span aria-hidden="true">&#x1F4CA;</span>}
+            label="戦績"
+            onClick={onShowStats}
+            aria-label="戦績を見る"
+          />
+          <Button
+            variant="footer"
+            icon={<span aria-hidden="true">&#x2699;</span>}
+            label="設定"
+            onClick={onShowSettings}
+            aria-label="設定を開く"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/__tests__/TitleScreen.test.tsx
+++ b/src/pages/__tests__/TitleScreen.test.tsx
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TitleScreen } from '../TitleScreen';
+
+describe('TitleScreen', () => {
+  const defaultProps = {
+    onStartSolo: vi.fn(),
+    onStartBattle: vi.fn(),
+    onShowRules: vi.fn(),
+    onShowStats: vi.fn(),
+    onShowSettings: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders the title screen container', () => {
+      render(<TitleScreen {...defaultProps} />);
+      // The container should have the titleScreen class
+      const container = document.querySelector('[class*="titleScreen"]');
+      expect(container).toBeInTheDocument();
+    });
+
+    it('displays the game title', () => {
+      render(<TitleScreen {...defaultProps} />);
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('にゃんポーカー');
+    });
+
+    it('displays the subtitle', () => {
+      render(<TitleScreen {...defaultProps} />);
+      expect(screen.getByText('猫カードで役を揃えるポーカーゲーム')).toBeInTheDocument();
+    });
+
+    it('renders four decorative cat cards', () => {
+      render(<TitleScreen {...defaultProps} />);
+      const images = screen.getAllByRole('img', { name: /装飾用猫カード/i });
+      expect(images).toHaveLength(4);
+    });
+
+    it('decorative cards have correct alt text', () => {
+      render(<TitleScreen {...defaultProps} />);
+      for (let i = 1; i <= 4; i++) {
+        expect(screen.getByAltText(`装飾用猫カード ${i}`)).toBeInTheDocument();
+      }
+    });
+
+    it('renders the solo mode button', () => {
+      render(<TitleScreen {...defaultProps} />);
+      expect(screen.getByRole('button', { name: /ひとりで遊ぶ/i })).toBeInTheDocument();
+    });
+
+    it('renders the battle mode button', () => {
+      render(<TitleScreen {...defaultProps} />);
+      expect(screen.getByRole('button', { name: /対戦モード/i })).toBeInTheDocument();
+    });
+
+    it('renders the rules button in footer', () => {
+      render(<TitleScreen {...defaultProps} />);
+      expect(screen.getByRole('button', { name: /遊び方/i })).toBeInTheDocument();
+    });
+
+    it('renders the stats button in footer', () => {
+      render(<TitleScreen {...defaultProps} />);
+      expect(screen.getByRole('button', { name: /戦績/i })).toBeInTheDocument();
+    });
+
+    it('renders the settings button in footer', () => {
+      render(<TitleScreen {...defaultProps} />);
+      expect(screen.getByRole('button', { name: /設定/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Decorative Cards', () => {
+    it('renders cards with correct image sources', () => {
+      render(<TitleScreen {...defaultProps} />);
+      const images = screen.getAllByRole('img', { name: /装飾用猫カード/i });
+
+      const expectedPaths = [
+        '/images/image_016.jpg',
+        '/images/image_028.jpg',
+        '/images/image_073.jpg',
+        '/images/image_023.jpg',
+      ];
+
+      images.forEach((img, index) => {
+        expect(img).toHaveAttribute('src', expectedPaths[index]);
+      });
+    });
+
+    it('renders cards with rotation styles', () => {
+      render(<TitleScreen {...defaultProps} />);
+      const cardContainers = document.querySelectorAll('[class*="titleCatCard"]');
+      expect(cardContainers).toHaveLength(4);
+
+      // Check that each card has a rotation style
+      const rotations = ['-12deg', '-4deg', '4deg', '12deg'];
+      cardContainers.forEach((card, index) => {
+        const style = card.getAttribute('style');
+        expect(style).toContain(`--rotation: ${rotations[index]}`);
+      });
+    });
+  });
+
+  describe('Button Interactions', () => {
+    it('calls onStartSolo when solo button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TitleScreen {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: /ひとりで遊ぶ/i }));
+      expect(defaultProps.onStartSolo).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onStartBattle when battle button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TitleScreen {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: /対戦モード/i }));
+      expect(defaultProps.onStartBattle).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onShowRules when rules button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TitleScreen {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: /遊び方/i }));
+      expect(defaultProps.onShowRules).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onShowStats when stats button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TitleScreen {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: /戦績/i }));
+      expect(defaultProps.onShowStats).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onShowSettings when settings button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TitleScreen {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: /設定/i }));
+      expect(defaultProps.onShowSettings).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('solo button has proper aria-label', () => {
+      render(<TitleScreen {...defaultProps} />);
+      const button = screen.getByRole('button', { name: /ひとりで遊ぶモードを開始/i });
+      expect(button).toBeInTheDocument();
+    });
+
+    it('battle button has proper aria-label', () => {
+      render(<TitleScreen {...defaultProps} />);
+      const button = screen.getByRole('button', { name: /対戦モードを開始/i });
+      expect(button).toBeInTheDocument();
+    });
+
+    it('rules button has proper aria-label', () => {
+      render(<TitleScreen {...defaultProps} />);
+      const button = screen.getByRole('button', { name: /遊び方を見る/i });
+      expect(button).toBeInTheDocument();
+    });
+
+    it('stats button has proper aria-label', () => {
+      render(<TitleScreen {...defaultProps} />);
+      const button = screen.getByRole('button', { name: /戦績を見る/i });
+      expect(button).toBeInTheDocument();
+    });
+
+    it('settings button has proper aria-label', () => {
+      render(<TitleScreen {...defaultProps} />);
+      const button = screen.getByRole('button', { name: /設定を開く/i });
+      expect(button).toBeInTheDocument();
+    });
+  });
+
+  describe('Component Structure', () => {
+    it('renders title logo section', () => {
+      render(<TitleScreen {...defaultProps} />);
+      const titleLogo = document.querySelector('[class*="titleLogo"]');
+      expect(titleLogo).toBeInTheDocument();
+    });
+
+    it('renders title cats section', () => {
+      render(<TitleScreen {...defaultProps} />);
+      const titleCats = document.querySelector('[class*="titleCats"]');
+      expect(titleCats).toBeInTheDocument();
+    });
+
+    it('renders title menu section', () => {
+      render(<TitleScreen {...defaultProps} />);
+      const titleMenu = document.querySelector('[class*="titleMenu"]');
+      expect(titleMenu).toBeInTheDocument();
+    });
+
+    it('renders title footer section', () => {
+      render(<TitleScreen {...defaultProps} />);
+      const titleFooter = document.querySelector('[class*="titleFooter"]');
+      expect(titleFooter).toBeInTheDocument();
+    });
+  });
+
+  describe('Footer Button Icons', () => {
+    it('rules button displays question mark icon', () => {
+      render(<TitleScreen {...defaultProps} />);
+      const rulesButton = screen.getByRole('button', { name: /遊び方を見る/i });
+      expect(rulesButton).toHaveTextContent('?');
+    });
+
+    it('footer buttons have labels', () => {
+      render(<TitleScreen {...defaultProps} />);
+
+      // Check that button labels are rendered
+      expect(screen.getByText('遊び方')).toBeInTheDocument();
+      expect(screen.getByText('戦績')).toBeInTheDocument();
+      expect(screen.getByText('設定')).toBeInTheDocument();
+    });
+  });
+
+  describe('Multiple Button Clicks', () => {
+    it('each button callback is called independently', async () => {
+      const user = userEvent.setup();
+      render(<TitleScreen {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: /ひとりで遊ぶモードを開始/i }));
+      await user.click(screen.getByRole('button', { name: /対戦モードを開始/i }));
+      await user.click(screen.getByRole('button', { name: /遊び方を見る/i }));
+      await user.click(screen.getByRole('button', { name: /戦績を見る/i }));
+      await user.click(screen.getByRole('button', { name: /設定を開く/i }));
+
+      expect(defaultProps.onStartSolo).toHaveBeenCalledTimes(1);
+      expect(defaultProps.onStartBattle).toHaveBeenCalledTimes(1);
+      expect(defaultProps.onShowRules).toHaveBeenCalledTimes(1);
+      expect(defaultProps.onShowStats).toHaveBeenCalledTimes(1);
+      expect(defaultProps.onShowSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it('clicking the same button multiple times calls callback multiple times', async () => {
+      const user = userEvent.setup();
+      render(<TitleScreen {...defaultProps} />);
+
+      const soloButton = screen.getByRole('button', { name: /ひとりで遊ぶモードを開始/i });
+      await user.click(soloButton);
+      await user.click(soloButton);
+      await user.click(soloButton);
+
+      expect(defaultProps.onStartSolo).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('Button Variants', () => {
+    it('solo button uses primary variant (has lg size)', () => {
+      render(<TitleScreen {...defaultProps} />);
+      const soloButton = screen.getByRole('button', { name: /ひとりで遊ぶモードを開始/i });
+      // Button with lg size should have the lg class
+      expect(soloButton.className).toMatch(/lg/i);
+    });
+
+    it('battle button uses secondary variant (has lg size)', () => {
+      render(<TitleScreen {...defaultProps} />);
+      const battleButton = screen.getByRole('button', { name: /対戦モードを開始/i });
+      // Button with lg size should have the lg class
+      expect(battleButton.className).toMatch(/lg/i);
+    });
+  });
+});

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,0 +1,3 @@
+// Pages exports
+export { TitleScreen } from './TitleScreen';
+export type { TitleScreenProps } from './TitleScreen';


### PR DESCRIPTION
## Summary
- Implement the TitleScreen component for the nyan-poker game title screen
- Add decorative cat card display with rotation animations
- Integrate TitleScreen with App component for screen navigation

## Changes
- Add TitleScreen.tsx component with:
  - Title logo with CSS cat ears decoration
  - Subtitle text
  - Four decorative cat card images with hover effects
  - Solo mode and Battle mode buttons
  - Footer buttons (rules, stats, settings)
- Add TitleScreen.module.css with responsive design
- Add comprehensive test suite (32 tests, 100% coverage)
- Update App.tsx to integrate TitleScreen with screen transition logic
- Add pages/index.ts for module exports

## Code Review Results

### 指摘事項と修正内容

| # | 指摘事項 | 対応内容 | 対応状況 |
|---|---------|---------|---------|
| - | 指摘事項なし | - | - |

## Test Results
- テスト実行結果: All tests passed (32/32)
- カバレッジ: 100% (TitleScreen.tsx)

## Related Issues
Closes #9

## Checklist
- [x] コードレビュー実施済み
- [x] テスト追加・更新済み
- [x] mock/index.html との整合性確認済み