### PR TITLE
Implement ResultScreen component (#12)

### DIFF
--- a/src/pages/ResultScreen.module.css
+++ b/src/pages/ResultScreen.module.css
@@ -1,0 +1,261 @@
+/* ResultScreen Container */
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: var(--space-5, 20px);
+  animation: fadeIn 0.4s ease-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.content {
+  max-width: 500px;
+  width: 100%;
+  text-align: center;
+}
+
+/* Score Section */
+.scoreSection {
+  margin-bottom: var(--space-8, 32px);
+}
+
+.scoreTitle {
+  font-size: var(--font-size-xl, 24px);
+  color: var(--color-text-muted, #c4bdb3);
+  margin-bottom: var(--space-3, 12px);
+  line-height: var(--line-height-normal, 1.5);
+  font-weight: 500;
+}
+
+.scoreValue {
+  font-size: 72px;
+  font-weight: 700;
+  color: var(--color-primary, #d4a574);
+  margin-bottom: var(--space-3, 12px);
+  line-height: var(--line-height-tight, 1.3);
+  animation: scorePopIn 0.6s ease-out;
+}
+
+@keyframes scorePopIn {
+  0% {
+    transform: scale(0.5);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.scoreLabel {
+  font-size: var(--font-size-lg, 20px);
+  color: var(--color-text-muted, #c4bdb3);
+  line-height: var(--line-height-normal, 1.5);
+}
+
+/* History Section */
+.historySection {
+  background: var(--color-bg-light, #3d3a35);
+  border-radius: var(--radius-lg, 12px);
+  padding: var(--space-5, 20px);
+  margin-bottom: var(--space-8, 32px);
+}
+
+.historyTitle {
+  font-size: var(--font-size-base, 14px);
+  color: var(--color-text-muted, #c4bdb3);
+  margin-bottom: var(--space-4, 16px);
+  line-height: var(--line-height-normal, 1.5);
+  font-weight: 500;
+}
+
+.historyList {
+  display: flex;
+  flex-direction: column;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.historyItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-3, 12px) 0;
+  border-bottom: 1px solid var(--color-card-bg, #4a4540);
+  animation: slideInItem 0.3s ease-out backwards;
+}
+
+.historyItem:last-child {
+  border-bottom: none;
+}
+
+/* Staggered animation for list items */
+.historyItem:nth-child(1) {
+  animation-delay: 0.1s;
+}
+.historyItem:nth-child(2) {
+  animation-delay: 0.15s;
+}
+.historyItem:nth-child(3) {
+  animation-delay: 0.2s;
+}
+.historyItem:nth-child(4) {
+  animation-delay: 0.25s;
+}
+.historyItem:nth-child(5) {
+  animation-delay: 0.3s;
+}
+
+@keyframes slideInItem {
+  from {
+    opacity: 0;
+    transform: translateX(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.roundInfo {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2, 8px);
+}
+
+.roundName {
+  color: var(--color-text, #f5f0e8);
+  font-size: var(--font-size-base, 14px);
+}
+
+.roleName {
+  font-size: var(--font-size-base, 14px);
+  color: var(--color-text-muted, #c4bdb3);
+  flex: 1;
+  text-align: center;
+}
+
+.points {
+  font-weight: 700;
+  font-size: var(--font-size-base, 14px);
+  min-width: 50px;
+  text-align: right;
+}
+
+.positive {
+  color: var(--color-success, #7eb87e);
+}
+
+.negative {
+  color: var(--color-danger, #c46b6b);
+}
+
+/* Result Icon (Battle Mode) */
+.resultIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--space-6, 24px);
+  height: var(--space-6, 24px);
+  border-radius: var(--radius-full, 9999px);
+  font-size: var(--font-size-sm, 13px);
+  font-weight: 700;
+}
+
+.iconWin {
+  background: var(--color-success, #7eb87e);
+  color: var(--color-bg, #2d2a26);
+}
+
+.iconLose {
+  background: var(--color-danger, #c46b6b);
+  color: var(--color-text, #f5f0e8);
+}
+
+.iconDraw {
+  background: var(--color-card-bg, #4a4540);
+  color: var(--color-text-muted, #c4bdb3);
+}
+
+/* Action Buttons */
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 12px);
+}
+
+/* Responsive adjustments */
+@media (max-width: 767px) {
+  .scoreValue {
+    font-size: var(--font-size-4xl, 56px);
+  }
+
+  .historySection {
+    padding: var(--space-4, 16px);
+  }
+
+  .historyItem {
+    padding: var(--space-2, 8px) 0;
+    flex-wrap: wrap;
+    gap: var(--space-2, 8px);
+  }
+
+  .roundInfo {
+    flex: 0 0 auto;
+  }
+
+  .roleName {
+    flex: 1 1 100%;
+    text-align: left;
+    order: 3;
+    padding-left: calc(var(--space-6, 24px) + var(--space-2, 8px));
+  }
+
+  .points {
+    flex: 0 0 auto;
+  }
+}
+
+@media (max-width: 400px) {
+  .content {
+    padding: 0 var(--space-2, 8px);
+  }
+
+  .scoreValue {
+    font-size: 48px;
+  }
+}
+
+/* Scrollbar styling for history list */
+.historyList::-webkit-scrollbar {
+  width: 6px;
+}
+
+.historyList::-webkit-scrollbar-track {
+  background: var(--color-card-bg, #4a4540);
+  border-radius: 3px;
+}
+
+.historyList::-webkit-scrollbar-thumb {
+  background: var(--color-text-muted, #c4bdb3);
+  border-radius: 3px;
+}
+
+.historyList::-webkit-scrollbar-thumb:hover {
+  background: var(--color-primary, #d4a574);
+}

--- a/src/pages/ResultScreen.tsx
+++ b/src/pages/ResultScreen.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { Button } from '../components/common';
+import type { GameMode, RoundHistory } from '../types';
+import styles from './ResultScreen.module.css';
+
+export interface ResultScreenProps {
+  /** Total score achieved in the game */
+  totalScore: number;
+  /** Round history with role and points for each round */
+  history: RoundHistory[];
+  /** Game mode (solo or battle) */
+  mode: GameMode;
+  /** Callback when "play again" button is clicked */
+  onPlayAgain: () => void;
+  /** Callback when "return to title" button is clicked */
+  onReturnToTitle: () => void;
+}
+
+/**
+ * ResultScreen component
+ *
+ * Displays the final score and round history after game completion.
+ * Provides options to play again or return to the title screen.
+ */
+export const ResultScreen: React.FC<ResultScreenProps> = ({
+  totalScore,
+  history,
+  mode,
+  onPlayAgain,
+  onReturnToTitle,
+}) => {
+  const isBattleMode = mode === 'battle';
+
+  /**
+   * Get CSS class for points based on value
+   */
+  const getPointsClass = (points: number): string => {
+    if (points > 0) return styles.positive;
+    if (points < 0) return styles.negative;
+    return '';
+  };
+
+  /**
+   * Format points with sign for display
+   */
+  const formatPoints = (points: number): string => {
+    if (points > 0) return `+${points}`;
+    return points.toString();
+  };
+
+  /**
+   * Get result icon for battle mode
+   */
+  const getResultIcon = (result?: 'win' | 'lose' | 'draw'): string => {
+    switch (result) {
+      case 'win':
+        return 'W';
+      case 'lose':
+        return 'L';
+      case 'draw':
+        return 'D';
+      default:
+        return '';
+    }
+  };
+
+  /**
+   * Get result icon CSS class
+   */
+  const getResultIconClass = (result?: 'win' | 'lose' | 'draw'): string => {
+    switch (result) {
+      case 'win':
+        return styles.iconWin;
+      case 'lose':
+        return styles.iconLose;
+      case 'draw':
+        return styles.iconDraw;
+      default:
+        return '';
+    }
+  };
+
+  return (
+    <div className={styles.container} data-testid="result-screen">
+      <div className={styles.content}>
+        {/* Final Score Display */}
+        <div className={styles.scoreSection}>
+          <h2 className={styles.scoreTitle}>最終スコア</h2>
+          <div
+            className={styles.scoreValue}
+            data-testid="final-score"
+            aria-label={`最終スコア: ${totalScore}ポイント`}
+          >
+            {totalScore}
+          </div>
+          <div className={styles.scoreLabel}>ポイント</div>
+        </div>
+
+        {/* Round History */}
+        <div className={styles.historySection}>
+          <h3 className={styles.historyTitle}>ラウンド履歴</h3>
+          <div
+            className={styles.historyList}
+            data-testid="round-history"
+            role="list"
+            aria-label="ラウンド履歴"
+          >
+            {history.map((round) => (
+              <div
+                key={round.round}
+                className={styles.historyItem}
+                role="listitem"
+                data-testid={`round-${round.round}`}
+              >
+                <div className={styles.roundInfo}>
+                  {isBattleMode && round.result && (
+                    <span
+                      className={`${styles.resultIcon} ${getResultIconClass(round.result)}`}
+                      aria-label={
+                        round.result === 'win'
+                          ? '勝利'
+                          : round.result === 'lose'
+                            ? '敗北'
+                            : '引き分け'
+                      }
+                    >
+                      {getResultIcon(round.result)}
+                    </span>
+                  )}
+                  <span className={styles.roundName}>
+                    ラウンド{round.round}
+                  </span>
+                </div>
+                <span className={styles.roleName}>{round.playerRole.name}</span>
+                <span
+                  className={`${styles.points} ${getPointsClass(round.playerPoints)}`}
+                >
+                  {formatPoints(round.playerPoints)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Action Buttons */}
+        <div className={styles.actions}>
+          <Button
+            variant="primary"
+            onClick={onPlayAgain}
+            data-testid="play-again-button"
+          >
+            もう一度遊ぶ
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={onReturnToTitle}
+            data-testid="return-to-title-button"
+          >
+            タイトルに戻る
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/__tests__/ResultScreen.test.tsx
+++ b/src/pages/__tests__/ResultScreen.test.tsx
@@ -1,0 +1,287 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ResultScreen } from '../ResultScreen';
+import type { RoundHistory, GameMode } from '../../types';
+import type { Role } from '../../types/role';
+
+// Helper to create mock role
+const createMockRole = (name: string, points: number): Role => ({
+  type: 'onePair',
+  name,
+  points,
+  matchingCardIds: [0, 1],
+});
+
+// Helper to create mock round history
+const createMockHistory = (
+  round: number,
+  roleName: string,
+  points: number,
+  result?: 'win' | 'lose' | 'draw'
+): RoundHistory => ({
+  round,
+  playerRole: createMockRole(roleName, points),
+  playerPoints: points,
+  result,
+});
+
+describe('ResultScreen', () => {
+  const defaultProps = {
+    totalScore: 85,
+    history: [
+      createMockHistory(1, '茶トラワンペア', 11),
+      createMockHistory(2, 'キジトラツーペア', 29),
+      createMockHistory(3, '茶白スリーカラー', 25),
+      createMockHistory(4, 'ノーペア', 0),
+      createMockHistory(5, '白猫×黒猫ツーペア', 20),
+    ],
+    mode: 'solo' as GameMode,
+    onPlayAgain: vi.fn(),
+    onReturnToTitle: vi.fn(),
+  };
+
+  describe('Basic Rendering', () => {
+    it('renders the result screen', () => {
+      render(<ResultScreen {...defaultProps} />);
+      expect(screen.getByTestId('result-screen')).toBeInTheDocument();
+    });
+
+    it('displays the final score title', () => {
+      render(<ResultScreen {...defaultProps} />);
+      expect(screen.getByText('最終スコア')).toBeInTheDocument();
+    });
+
+    it('displays the total score', () => {
+      render(<ResultScreen {...defaultProps} />);
+      expect(screen.getByTestId('final-score')).toHaveTextContent('85');
+    });
+
+    it('displays the points label', () => {
+      render(<ResultScreen {...defaultProps} />);
+      expect(screen.getByText('ポイント')).toBeInTheDocument();
+    });
+
+    it('displays the round history title', () => {
+      render(<ResultScreen {...defaultProps} />);
+      expect(screen.getByText('ラウンド履歴')).toBeInTheDocument();
+    });
+
+    it('displays all round history items', () => {
+      render(<ResultScreen {...defaultProps} />);
+      expect(screen.getByTestId('round-1')).toBeInTheDocument();
+      expect(screen.getByTestId('round-2')).toBeInTheDocument();
+      expect(screen.getByTestId('round-3')).toBeInTheDocument();
+      expect(screen.getByTestId('round-4')).toBeInTheDocument();
+      expect(screen.getByTestId('round-5')).toBeInTheDocument();
+    });
+  });
+
+  describe('Solo Mode Display', () => {
+    it('displays round numbers', () => {
+      render(<ResultScreen {...defaultProps} />);
+      expect(screen.getByText('ラウンド1')).toBeInTheDocument();
+      expect(screen.getByText('ラウンド2')).toBeInTheDocument();
+      expect(screen.getByText('ラウンド5')).toBeInTheDocument();
+    });
+
+    it('displays role names', () => {
+      render(<ResultScreen {...defaultProps} />);
+      expect(screen.getByText('茶トラワンペア')).toBeInTheDocument();
+      expect(screen.getByText('キジトラツーペア')).toBeInTheDocument();
+      expect(screen.getByText('茶白スリーカラー')).toBeInTheDocument();
+    });
+
+    it('displays positive points with + sign', () => {
+      render(<ResultScreen {...defaultProps} />);
+      expect(screen.getByText('+11')).toBeInTheDocument();
+      expect(screen.getByText('+29')).toBeInTheDocument();
+    });
+
+    it('displays zero points without sign', () => {
+      render(<ResultScreen {...defaultProps} />);
+      expect(screen.getByText('0')).toBeInTheDocument();
+    });
+
+    it('does not display result icons in solo mode', () => {
+      render(<ResultScreen {...defaultProps} />);
+      expect(screen.queryByText('W')).not.toBeInTheDocument();
+      expect(screen.queryByText('L')).not.toBeInTheDocument();
+      expect(screen.queryByText('D')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Battle Mode Display', () => {
+    const battleHistory = [
+      createMockHistory(1, '茶トラワンペア', 11, 'win'),
+      createMockHistory(2, 'キジトラツーペア', -15, 'lose'),
+      createMockHistory(3, '茶白スリーカラー', 0, 'draw'),
+    ];
+
+    const battleProps = {
+      ...defaultProps,
+      mode: 'battle' as GameMode,
+      history: battleHistory,
+      totalScore: -4,
+    };
+
+    it('displays result icons in battle mode', () => {
+      render(<ResultScreen {...battleProps} />);
+      expect(screen.getByText('W')).toBeInTheDocument();
+    });
+
+    it('displays lose icon for losing rounds', () => {
+      render(<ResultScreen {...battleProps} />);
+      expect(screen.getByText('L')).toBeInTheDocument();
+    });
+
+    it('displays draw icon for draw rounds', () => {
+      render(<ResultScreen {...battleProps} />);
+      expect(screen.getByText('D')).toBeInTheDocument();
+    });
+
+    it('displays negative points for losing rounds', () => {
+      render(<ResultScreen {...battleProps} />);
+      expect(screen.getByText('-15')).toBeInTheDocument();
+    });
+  });
+
+  describe('Score Display', () => {
+    it('displays positive total score correctly', () => {
+      render(<ResultScreen {...defaultProps} totalScore={150} />);
+      expect(screen.getByTestId('final-score')).toHaveTextContent('150');
+    });
+
+    it('displays zero total score correctly', () => {
+      render(<ResultScreen {...defaultProps} totalScore={0} />);
+      expect(screen.getByTestId('final-score')).toHaveTextContent('0');
+    });
+
+    it('displays negative total score correctly', () => {
+      render(<ResultScreen {...defaultProps} totalScore={-25} />);
+      expect(screen.getByTestId('final-score')).toHaveTextContent('-25');
+    });
+
+    it('has accessible label for score', () => {
+      render(<ResultScreen {...defaultProps} totalScore={85} />);
+      expect(screen.getByLabelText('最終スコア: 85ポイント')).toBeInTheDocument();
+    });
+  });
+
+  describe('Button Interactions', () => {
+    it('calls onPlayAgain when play again button is clicked', () => {
+      const onPlayAgain = vi.fn();
+      render(<ResultScreen {...defaultProps} onPlayAgain={onPlayAgain} />);
+
+      fireEvent.click(screen.getByTestId('play-again-button'));
+      expect(onPlayAgain).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onReturnToTitle when return to title button is clicked', () => {
+      const onReturnToTitle = vi.fn();
+      render(<ResultScreen {...defaultProps} onReturnToTitle={onReturnToTitle} />);
+
+      fireEvent.click(screen.getByTestId('return-to-title-button'));
+      expect(onReturnToTitle).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders play again button with correct text', () => {
+      render(<ResultScreen {...defaultProps} />);
+      expect(screen.getByText('もう一度遊ぶ')).toBeInTheDocument();
+    });
+
+    it('renders return to title button with correct text', () => {
+      render(<ResultScreen {...defaultProps} />);
+      expect(screen.getByText('タイトルに戻る')).toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('has accessible history list', () => {
+      render(<ResultScreen {...defaultProps} />);
+      expect(screen.getByRole('list', { name: 'ラウンド履歴' })).toBeInTheDocument();
+    });
+
+    it('has list items for each round', () => {
+      render(<ResultScreen {...defaultProps} />);
+      const listItems = screen.getAllByRole('listitem');
+      expect(listItems).toHaveLength(5);
+    });
+
+    it('has accessible labels for result icons in battle mode', () => {
+      const battleHistory = [
+        createMockHistory(1, '茶トラワンペア', 11, 'win'),
+        createMockHistory(2, 'キジトラツーペア', -15, 'lose'),
+        createMockHistory(3, '茶白スリーカラー', 0, 'draw'),
+      ];
+
+      render(
+        <ResultScreen
+          {...defaultProps}
+          mode="battle"
+          history={battleHistory}
+        />
+      );
+
+      expect(screen.getByLabelText('勝利')).toBeInTheDocument();
+      expect(screen.getByLabelText('敗北')).toBeInTheDocument();
+      expect(screen.getByLabelText('引き分け')).toBeInTheDocument();
+    });
+
+    it('buttons are focusable', () => {
+      render(<ResultScreen {...defaultProps} />);
+
+      const playAgainButton = screen.getByTestId('play-again-button');
+      const returnButton = screen.getByTestId('return-to-title-button');
+
+      expect(playAgainButton).not.toHaveAttribute('disabled');
+      expect(returnButton).not.toHaveAttribute('disabled');
+    });
+  });
+
+  describe('Empty History', () => {
+    it('renders correctly with empty history', () => {
+      render(<ResultScreen {...defaultProps} history={[]} totalScore={0} />);
+
+      expect(screen.getByText('最終スコア')).toBeInTheDocument();
+      expect(screen.getByTestId('final-score')).toHaveTextContent('0');
+      expect(screen.getByText('ラウンド履歴')).toBeInTheDocument();
+    });
+  });
+
+  describe('Points Styling', () => {
+    it('applies positive styling class for positive points', () => {
+      const history = [createMockHistory(1, 'テスト役', 25)];
+      render(<ResultScreen {...defaultProps} history={history} />);
+
+      const pointsElement = screen.getByText('+25');
+      expect(pointsElement.className).toContain('positive');
+    });
+
+    it('applies negative styling class for negative points', () => {
+      const history = [createMockHistory(1, 'テスト役', -10)];
+      history[0].playerPoints = -10;
+      render(<ResultScreen {...defaultProps} history={history} />);
+
+      const pointsElement = screen.getByText('-10');
+      expect(pointsElement.className).toContain('negative');
+    });
+
+    it('does not apply special styling for zero points', () => {
+      const history = [createMockHistory(1, 'ノーペア', 0)];
+      render(<ResultScreen {...defaultProps} history={history} />);
+
+      // Find the points element (not the score value)
+      const historyItem = screen.getByTestId('round-1');
+      const pointsElement = historyItem.querySelector('[class*="points"]');
+      expect(pointsElement?.className).not.toContain('positive');
+      expect(pointsElement?.className).not.toContain('negative');
+    });
+  });
+});
+
+describe('ResultScreen index export', () => {
+  it('exports ResultScreen from index', async () => {
+    const { ResultScreen } = await import('../index');
+    expect(ResultScreen).toBeDefined();
+  });
+});

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,3 +1,5 @@
 // Pages exports
+export { ResultScreen } from './ResultScreen';
+export type { ResultScreenProps } from './ResultScreen';
 export { TitleScreen } from './TitleScreen';
 export type { TitleScreenProps } from './TitleScreen';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
## Summary

- ResultScreen component for displaying game results after all rounds complete
- Shows final score with animation effect
- Displays round history with role names and points
- Battle mode support with win/lose/draw icons
- Accessibility features with aria labels and roles

## Changes

- Add `src/pages/ResultScreen.tsx` - Main component implementation
- Add `src/pages/ResultScreen.module.css` - Styles with animations
- Add `src/pages/__tests__/ResultScreen.test.tsx` - 32 test cases
- Update `src/pages/index.ts` - Export ResultScreen
- Update `tsconfig.json` - Exclude test files from build

## Code Review Results

### 指摘事項と修正内容

| # | 指摘事項 | 対応内容 | 対応状況 |
|---|---------|---------|---------|
| - | 指摘事項なし | - | - |

## Test Results

- テスト実行結果: All tests passed (432/432)
- ResultScreenカバレッジ: 91.3%

## Related Issues

Closes #12

## Checklist

- [x] コードレビュー実施済み
- [x] テスト追加・更新済み
- [x] mock/index.html との整合性確認済み