### PR TITLE
Implement role highlight animation for winning hands (#19)

### DIFF
--- a/src/components/card/Card.module.css
+++ b/src/components/card/Card.module.css
@@ -101,26 +101,29 @@
 /* Role Matching States */
 /* ==================== */
 
-/* Card is part of winning hand - glowing effect */
+/* Card is part of winning hand - glowing effect with scale */
 .card--matching {
   border-color: var(--color-primary, #d4a574);
-  animation: cardGlow 1s ease-in-out infinite;
+  animation: cardGlowWithScale 1.5s ease-in-out infinite;
 }
 
-@keyframes cardGlow {
+@keyframes cardGlowWithScale {
   0%,
   100% {
-    box-shadow: 0 0 20px rgba(212, 165, 116, 0.6);
+    box-shadow: 0 0 0px rgba(255, 215, 0, 0);
+    transform: scale(1);
   }
   50% {
-    box-shadow: 0 0 35px rgba(212, 165, 116, 1);
+    box-shadow: 0 0 20px rgba(255, 215, 0, 0.8);
+    transform: scale(1.05);
   }
 }
 
 /* Card is not part of winning hand - dimmed */
 .card--not-matching {
   opacity: 0.5;
-  filter: grayscale(40%);
+  filter: grayscale(100%);
+  transition: opacity 0.3s ease-out, filter 0.3s ease-out;
 }
 
 /* ==================== */

--- a/src/components/game/RoleDisplay.module.css
+++ b/src/components/game/RoleDisplay.module.css
@@ -15,26 +15,31 @@
 .container--visible {
   visibility: visible;
   opacity: 1;
-  animation: fadeIn 0.3s ease-out;
 }
 
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(-10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
+/* Role name with pop-in animation */
 .role-name {
   font-size: var(--font-size-2xl, 28px);
   font-weight: 700;
   color: var(--color-primary, #d4a574);
   text-align: center;
   margin: 0;
+  animation: rolePopIn 0.5s ease-out forwards;
+}
+
+@keyframes rolePopIn {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.2);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
 }
 
 .role-name--no-pair {

--- a/src/components/game/RoleDisplay.tsx
+++ b/src/components/game/RoleDisplay.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import type { Role } from '../../types';
 import styles from './RoleDisplay.module.css';
+
+/** Delay before role name pop-in starts (ms) */
+const ROLE_NAME_DELAY = 200;
 
 export interface RoleDisplayProps {
   role: Role | null;
@@ -8,6 +11,22 @@ export interface RoleDisplayProps {
 }
 
 export const RoleDisplay: React.FC<RoleDisplayProps> = ({ role, visible }) => {
+  const [showRole, setShowRole] = useState(false);
+
+  // Handle delayed role name display
+  useEffect(() => {
+    if (visible && role) {
+      // Reset first to trigger animation on role change
+      setShowRole(false);
+      const timer = setTimeout(() => {
+        setShowRole(true);
+      }, ROLE_NAME_DELAY);
+      return () => clearTimeout(timer);
+    } else {
+      setShowRole(false);
+    }
+  }, [visible, role]);
+
   const containerClasses = [
     styles.container,
     visible ? styles['container--visible'] : styles['container--hidden'],
@@ -21,10 +40,11 @@ export const RoleDisplay: React.FC<RoleDisplayProps> = ({ role, visible }) => {
   };
 
   const getRoleNameClass = () => {
+    const classes = [styles['role-name']];
     if (!role || role.type === 'noPair') {
-      return `${styles['role-name']} ${styles['role-name--no-pair']}`;
+      classes.push(styles['role-name--no-pair']);
     }
-    return styles['role-name'];
+    return classes.join(' ');
   };
 
   const formatPoints = (points: number): string => {
@@ -34,7 +54,7 @@ export const RoleDisplay: React.FC<RoleDisplayProps> = ({ role, visible }) => {
 
   return (
     <div className={containerClasses} aria-live="polite">
-      {role && visible && (
+      {role && visible && showRole && (
         <>
           <h2 className={getRoleNameClass()}>{role.name}</h2>
           <span className={getPointsClass()}>

--- a/src/components/game/__tests__/RoleDisplay.test.tsx
+++ b/src/components/game/__tests__/RoleDisplay.test.tsx
@@ -1,0 +1,266 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { RoleDisplay } from '../RoleDisplay';
+import type { Role } from '../../../types';
+
+describe('RoleDisplay', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  const mockRole: Role = {
+    type: 'flush',
+    name: 'Test Flush',
+    points: 100,
+    matchingCardIds: [1, 2, 3, 4, 5],
+  };
+
+  const noPairRole: Role = {
+    type: 'noPair',
+    name: 'No Pair',
+    points: 0,
+    matchingCardIds: [],
+  };
+
+  const negativePointsRole: Role = {
+    type: 'flush',
+    name: 'Test Role',
+    points: -50,
+    matchingCardIds: [1, 2, 3, 4, 5],
+  };
+
+  describe('visibility', () => {
+    it('should have hidden class when visible is false', () => {
+      const { container } = render(<RoleDisplay role={mockRole} visible={false} />);
+      const element = container.querySelector('[aria-live="polite"]');
+      expect(element?.className).toMatch(/container--hidden/);
+    });
+
+    it('should have visible class when visible is true', () => {
+      const { container } = render(<RoleDisplay role={mockRole} visible={true} />);
+      const element = container.querySelector('[aria-live="polite"]');
+      expect(element?.className).toMatch(/container--visible/);
+    });
+
+    it('should not render role content when role is null', () => {
+      render(<RoleDisplay role={null} visible={true} />);
+
+      // Advance timers to check that nothing appears
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+    });
+
+    it('should not render role content when visible is false', () => {
+      render(<RoleDisplay role={mockRole} visible={false} />);
+
+      // Advance timers to check that nothing appears
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('delayed role name display', () => {
+    it('should delay role name display by 200ms', () => {
+      render(<RoleDisplay role={mockRole} visible={true} />);
+
+      // Initially, role name should not be displayed
+      expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+
+      // Advance timers by 100ms - still should not be visible
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+      expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+
+      // Advance timers by another 100ms (total 200ms) - now should be visible
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+      expect(screen.getByRole('heading', { name: 'Test Flush' })).toBeInTheDocument();
+    });
+
+    it('should reset and re-trigger animation when role changes', () => {
+      const { rerender } = render(<RoleDisplay role={mockRole} visible={true} />);
+
+      // Advance timers to show first role
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(screen.getByRole('heading', { name: 'Test Flush' })).toBeInTheDocument();
+
+      // Change the role
+      const newRole: Role = {
+        type: 'fullHouse',
+        name: 'Full House',
+        points: 150,
+        matchingCardIds: [1, 2, 3, 4, 5],
+      };
+
+      rerender(<RoleDisplay role={newRole} visible={true} />);
+
+      // Role name should be hidden again during delay
+      expect(screen.queryByRole('heading', { name: 'Full House' })).not.toBeInTheDocument();
+
+      // Advance timers by 200ms
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      // Now new role name should be displayed
+      expect(screen.getByRole('heading', { name: 'Full House' })).toBeInTheDocument();
+    });
+
+    it('should cleanup timer on unmount', () => {
+      const { unmount } = render(<RoleDisplay role={mockRole} visible={true} />);
+
+      // Unmount before timer fires
+      unmount();
+
+      // Should not throw any errors
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+    });
+  });
+
+  describe('role name styling', () => {
+    it('should have no-pair styling for noPair role', () => {
+      render(<RoleDisplay role={noPairRole} visible={true} />);
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      const heading = screen.getByRole('heading', { name: 'No Pair' });
+      expect(heading.className).toMatch(/role-name--no-pair/);
+    });
+
+    it('should not have no-pair styling for other roles', () => {
+      render(<RoleDisplay role={mockRole} visible={true} />);
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      const heading = screen.getByRole('heading', { name: 'Test Flush' });
+      expect(heading.className).not.toMatch(/role-name--no-pair/);
+    });
+  });
+
+  describe('points display', () => {
+    it('should display positive points with + prefix', () => {
+      render(<RoleDisplay role={mockRole} visible={true} />);
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(screen.getByText('+100 ポイント')).toBeInTheDocument();
+    });
+
+    it('should display zero points without prefix', () => {
+      render(<RoleDisplay role={noPairRole} visible={true} />);
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(screen.getByText('0 ポイント')).toBeInTheDocument();
+    });
+
+    it('should display negative points with - prefix', () => {
+      render(<RoleDisplay role={negativePointsRole} visible={true} />);
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(screen.getByText('-50 ポイント')).toBeInTheDocument();
+    });
+
+    it('should have positive class for positive points', () => {
+      render(<RoleDisplay role={mockRole} visible={true} />);
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      const pointsElement = screen.getByText('+100 ポイント');
+      expect(pointsElement.className).toMatch(/points--positive/);
+    });
+
+    it('should have zero class for zero points', () => {
+      render(<RoleDisplay role={noPairRole} visible={true} />);
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      const pointsElement = screen.getByText('0 ポイント');
+      expect(pointsElement.className).toMatch(/points--zero/);
+    });
+
+    it('should have negative class for negative points', () => {
+      render(<RoleDisplay role={negativePointsRole} visible={true} />);
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      const pointsElement = screen.getByText('-50 ポイント');
+      expect(pointsElement.className).toMatch(/points--negative/);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should have aria-live attribute for screen readers', () => {
+      const { container } = render(<RoleDisplay role={mockRole} visible={true} />);
+      const element = container.querySelector('[aria-live="polite"]');
+      expect(element).toBeInTheDocument();
+      expect(element).toHaveAttribute('aria-live', 'polite');
+    });
+  });
+
+  describe('hiding role', () => {
+    it('should hide role when visible becomes false', () => {
+      const { rerender } = render(<RoleDisplay role={mockRole} visible={true} />);
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(screen.getByRole('heading', { name: 'Test Flush' })).toBeInTheDocument();
+
+      rerender(<RoleDisplay role={mockRole} visible={false} />);
+
+      expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+    });
+
+    it('should hide role when role becomes null', () => {
+      const { rerender } = render(<RoleDisplay role={mockRole} visible={true} />);
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(screen.getByRole('heading', { name: 'Test Flush' })).toBeInTheDocument();
+
+      rerender(<RoleDisplay role={null} visible={true} />);
+
+      expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/BattleScreen.tsx
+++ b/src/pages/BattleScreen.tsx
@@ -19,7 +19,8 @@ const TOTAL_ROUNDS = 5;
 const HAND_SIZE = 5;
 const EXCHANGE_ANIMATION_DELAY = 400;
 const DEALER_EXCHANGE_DELAY = 800;
-const REVEAL_DELAY = 500;
+/** Delay before role highlight starts after exchange completes (ms) */
+const ROLE_HIGHLIGHT_DELAY = 300;
 const DEALER_ICON = '\uD83C\uDFA9'; // Top hat emoji
 const PLAYER_ICON = '\uD83D\uDC31'; // Cat emoji
 
@@ -122,6 +123,7 @@ export const BattleScreen: React.FC<BattleScreenProps> = ({
   const revealRoles = useCallback(() => {
     setPhase('revealing');
 
+    // Wait for ROLE_HIGHLIGHT_DELAY before showing role highlight
     setTimeout(() => {
       // Calculate roles
       const pRole = calculateRole(playerHand);
@@ -159,7 +161,7 @@ export const BattleScreen: React.FC<BattleScreenProps> = ({
 
       setPhase('result');
       setShowResultOverlay(true);
-    }, REVEAL_DELAY);
+    }, ROLE_HIGHLIGHT_DELAY);
   }, [playerHand, dealerHand, round]);
 
   const handleExchange = useCallback(() => {

--- a/src/pages/GameScreen.tsx
+++ b/src/pages/GameScreen.tsx
@@ -10,6 +10,8 @@ const MAX_SELECTABLE_CARDS = 3;
 const TOTAL_ROUNDS = 5;
 const HAND_SIZE = 5;
 const EXCHANGE_ANIMATION_DELAY = 400;
+/** Delay before role highlight starts after exchange completes (ms) */
+const ROLE_HIGHLIGHT_DELAY = 300;
 
 export interface GameScreenProps {
   onGameEnd: (finalScore: number, history: RoundHistory[]) => void;
@@ -120,6 +122,7 @@ export const GameScreen: React.FC<GameScreenProps> = ({
   const revealRole = useCallback(() => {
     setPhase('revealing');
 
+    // Wait for ROLE_HIGHLIGHT_DELAY before showing role highlight
     setTimeout(() => {
       const role = calculateRole(hand.length === 5 ? hand : []);
       setCurrentRole(role);
@@ -132,7 +135,7 @@ export const GameScreen: React.FC<GameScreenProps> = ({
       setHistory((prev) => [...prev, roundHistory]);
       setScore((prev) => prev + role.points);
       setPhase('result');
-    }, 100);
+    }, ROLE_HIGHLIGHT_DELAY);
   }, [hand, round]);
 
   useEffect(() => {

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -67,26 +67,29 @@
   animation: cardEnterFromTop 0.4s ease-out forwards;
 }
 
-/* 役成立時のカードハイライト */
-@keyframes cardGlow {
+/* 役成立時のカードハイライト - 光るエフェクトとスケールアニメーション */
+@keyframes cardGlowWithScale {
   0%,
   100% {
-    box-shadow: 0 0 20px rgba(212, 165, 116, 0.6);
+    box-shadow: 0 0 0px rgba(255, 215, 0, 0);
+    transform: scale(1);
   }
   50% {
-    box-shadow: 0 0 35px rgba(212, 165, 116, 1);
+    box-shadow: 0 0 20px rgba(255, 215, 0, 0.8);
+    transform: scale(1.05);
   }
 }
 
 .card-wrapper.role-match .card {
   border-color: var(--color-primary);
-  animation: cardGlow 1s ease-in-out infinite;
+  animation: cardGlowWithScale 1.5s ease-in-out infinite;
 }
 
 /* 役非構成カードの暗転 */
 .card-wrapper.role-no-match .card {
   opacity: 0.5;
-  filter: grayscale(40%);
+  filter: grayscale(100%);
+  transition: opacity 0.3s ease-out, filter 0.3s ease-out;
 }
 
 /* 役名ポップイン */


### PR DESCRIPTION
## Summary

- Implement card highlight animation when a poker hand is formed
- Add pop-in animation for role name display
- Improve visual feedback for winning and non-winning cards

## Changes

- **Card highlight**: Added golden glow with scale animation (1.0 -> 1.05 -> 1.0) for cards that are part of the winning hand
- **Card dimming**: Updated grayscale filter from 40% to 100% for non-matching cards
- **Role name animation**: Added pop-in animation with scale effect (0 -> 1.2 -> 1.0) and 200ms delay
- **Timing control**: Added 300ms delay after exchange completes before showing highlights
- **Test coverage**: Added comprehensive tests for RoleDisplay component

## Code Review Results

### Observations and Decisions

| # | Item | Decision | Status |
|---|------|----------|--------|
| 1 | Animation definitions in both Card.module.css and animations.css | Both files updated to maintain consistency with existing project pattern | OK |
| 2 | GameScreen.tsx react-hooks/exhaustive-deps warning | Existing issue, not introduced by this change | OK |

## Test Results

- Test execution result: All tests passed (610/610)
- Coverage: 90.12%

## Related Issues

Closes #19

## Checklist

- [x] Code review completed
- [x] Tests added/updated
- [x] Mock/index.html consistency confirmed (animation behavior matches spec)