### PR TITLE
レスポンシブデザイン対応 (#26)

### DIFF
--- a/src/components/card/Card.module.css
+++ b/src/components/card/Card.module.css
@@ -19,21 +19,6 @@
   background: var(--color-card-bg, #4a4540);
 }
 
-/* Responsive sizes */
-@media (min-width: 768px) {
-  .card {
-    width: 120px;
-    height: 160px;
-  }
-}
-
-@media (min-width: 1024px) {
-  .card {
-    width: var(--card-width-pc, 150px);
-    height: var(--card-height-pc, 200px);
-  }
-}
-
 /* ==================== */
 /* Interactive States */
 /* ==================== */
@@ -248,4 +233,25 @@
     transform: translateY(-50px);
     opacity: 0;
   }
+}
+
+/* ==================== */
+/* Touch Device Support */
+/* ==================== */
+
+/* タッチデバイスでのホバー状態フォールバック */
+@media (hover: none) {
+  .card--clickable:hover {
+    transform: none;
+  }
+
+  .card--clickable:active {
+    transform: scale(0.98);
+  }
+}
+
+/* タップ領域の確保 */
+.card--clickable {
+  min-width: var(--min-tap-size, 44px);
+  min-height: var(--min-tap-size, 44px);
 }

--- a/src/components/card/Hand.module.css
+++ b/src/components/card/Hand.module.css
@@ -5,26 +5,8 @@
 .hand {
   display: flex;
   justify-content: center;
-  gap: var(--space-3, 12px);
+  gap: var(--card-gap, 8px);
   flex-wrap: wrap;
-}
-
-@media (min-width: 768px) {
-  .hand {
-    gap: var(--space-4, 16px);
-  }
-}
-
-@media (min-width: 1024px) {
-  .hand {
-    gap: var(--space-5, 20px);
-  }
-}
-
-@media (max-width: 767px) {
-  .hand {
-    gap: var(--space-2, 8px);
-  }
 }
 
 /* ==================== */
@@ -49,27 +31,13 @@
 /* ==================== */
 
 .hand--dealer {
-  gap: var(--space-2, 8px);
+  gap: calc(var(--card-gap, 8px) * 0.8);
 }
 
-/* Dealer cards are 80% size */
+/* Dealer cards are 80% size - use CSS variables set in variables.css */
 .hand--dealer .hand__card-wrapper [class*='card'] {
-  width: calc(var(--card-width, 80px) * 0.8);
-  height: calc(var(--card-height, 107px) * 0.8);
-}
-
-@media (min-width: 768px) {
-  .hand--dealer .hand__card-wrapper [class*='card'] {
-    width: calc(120px * 0.8);
-    height: calc(160px * 0.8);
-  }
-}
-
-@media (min-width: 1024px) {
-  .hand--dealer .hand__card-wrapper [class*='card'] {
-    width: var(--dealer-card-width-pc, 120px);
-    height: var(--dealer-card-height-pc, 160px);
-  }
+  width: var(--dealer-card-width, 64px);
+  height: var(--dealer-card-height, 86px);
 }
 
 /* Dealer cards don't hover */
@@ -79,14 +47,31 @@
 
 /* Dealer card info is slightly smaller */
 .hand--dealer .hand__card-wrapper [class*='card-info'] {
-  font-size: var(--font-size-base, 14px);
-  min-height: 36px;
+  font-size: var(--font-size-sm, 13px);
+  min-height: 32px;
 }
 
+/* スマートフォン (767px以下) */
 @media (max-width: 767px) {
   .hand--dealer .hand__card-wrapper [class*='card-info'] {
     font-size: var(--font-size-xs, 11px);
+    min-height: 24px;
+  }
+}
+
+/* タブレット (768px以上) */
+@media (min-width: 768px) {
+  .hand--dealer .hand__card-wrapper [class*='card-info'] {
+    font-size: var(--font-size-sm, 13px);
     min-height: 28px;
+  }
+}
+
+/* PC (1024px以上) */
+@media (min-width: 1024px) {
+  .hand--dealer .hand__card-wrapper [class*='card-info'] {
+    font-size: var(--font-size-base, 14px);
+    min-height: 36px;
   }
 }
 

--- a/src/components/common/Button.module.css
+++ b/src/components/common/Button.module.css
@@ -14,6 +14,9 @@
   gap: var(--space-2, 8px);
   position: relative;
   white-space: nowrap;
+  /* タッチ操作対応: 最小タップ領域確保 */
+  min-height: var(--min-tap-size, 44px);
+  min-width: var(--min-tap-size, 44px);
 }
 
 .btn:disabled {
@@ -169,4 +172,60 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+}
+
+/* ==================== */
+/* Touch Device Support */
+/* ==================== */
+
+/* タッチデバイスでのホバー状態フォールバック */
+@media (hover: none) {
+  .btn--primary:not(:disabled):hover {
+    transform: none;
+    box-shadow: var(--shadow-glow, 0 4px 12px rgba(212, 165, 116, 0.3));
+  }
+
+  .btn--primary:not(:disabled):active {
+    transform: scale(0.95);
+  }
+
+  .btn--footer:not(:disabled):hover {
+    transform: none;
+  }
+
+  .btn--footer:not(:disabled):active {
+    transform: scale(0.95);
+  }
+}
+
+/* ==================== */
+/* Responsive Styles */
+/* ==================== */
+
+/* スマートフォン (767px以下) */
+@media (max-width: 767px) {
+  .btn {
+    padding: var(--space-3, 12px) var(--space-5, 20px);
+    font-size: var(--font-size-base, 14px);
+  }
+
+  .btn--sm {
+    padding: var(--space-2, 8px) var(--space-3, 12px);
+    font-size: var(--font-size-sm, 13px);
+  }
+
+  .btn--lg {
+    padding: var(--space-4, 16px) var(--space-8, 32px);
+    font-size: var(--font-size-md, 16px);
+  }
+
+  .btn--footer {
+    padding: var(--space-2, 8px) var(--space-3, 12px);
+  }
+
+  .btn-footer-icon {
+    width: var(--space-6, 24px);
+    height: var(--space-6, 24px);
+    font-size: var(--font-size-md, 16px);
+  }
 }

--- a/src/components/common/Modal.module.css
+++ b/src/components/common/Modal.module.css
@@ -116,14 +116,21 @@
   background: var(--color-primary, #d4a574);
 }
 
-/* Responsive */
-@media (max-width: 768px) {
+/* ==================== */
+/* Responsive Styles */
+/* ==================== */
+
+/* スマートフォン (767px以下) - フルスクリーン風表示 */
+@media (max-width: 767px) {
   .overlay {
     padding: var(--space-2, 8px);
+    align-items: flex-end;
   }
 
   .modal {
     max-height: 95vh;
+    border-radius: var(--radius-xl, 20px) var(--radius-xl, 20px) 0 0;
+    max-width: 100%;
   }
 
   .header {
@@ -134,7 +141,56 @@
     font-size: var(--font-size-lg, 20px);
   }
 
+  .closeButton {
+    min-width: var(--min-tap-size, 44px);
+    min-height: var(--min-tap-size, 44px);
+  }
+
   .body {
     padding: var(--space-4, 16px);
+  }
+}
+
+/* Very small screens - 完全フルスクリーン */
+@media (max-width: 400px) {
+  .overlay {
+    padding: 0;
+    align-items: stretch;
+  }
+
+  .modal {
+    max-height: 100vh;
+    height: 100vh;
+    border-radius: 0;
+  }
+}
+
+/* タブレット (768px以上) */
+@media (min-width: 768px) {
+  .modal {
+    max-width: 550px;
+  }
+
+  .header {
+    padding: var(--space-5, 20px);
+  }
+
+  .body {
+    padding: var(--space-5, 20px);
+  }
+}
+
+/* PC (1024px以上) */
+@media (min-width: 1024px) {
+  .modal {
+    max-width: 600px;
+  }
+
+  .header {
+    padding: var(--space-6, 24px);
+  }
+
+  .body {
+    padding: var(--space-6, 24px);
   }
 }

--- a/src/components/game/GameHeader.module.css
+++ b/src/components/game/GameHeader.module.css
@@ -3,7 +3,7 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  max-width: 800px;
+  max-width: 900px;
   margin-bottom: var(--space-5, 20px);
   flex-wrap: wrap;
   gap: var(--space-3, 12px);
@@ -61,10 +61,10 @@
 }
 
 .rules-button {
-  width: 48px;
-  height: 48px;
-  min-width: 48px;
-  min-height: 48px;
+  width: var(--min-tap-size, 44px);
+  height: var(--min-tap-size, 44px);
+  min-width: var(--min-tap-size, 44px);
+  min-height: var(--min-tap-size, 44px);
   padding: 0;
   border-radius: var(--radius-full, 9999px);
   display: flex;
@@ -85,4 +85,78 @@
 .rules-button:focus-visible {
   outline: 3px solid var(--color-primary-light, #e8c9a0);
   outline-offset: 2px;
+}
+
+/* ==================== */
+/* Responsive Styles */
+/* ==================== */
+
+/* スマートフォン (767px以下) - ヘッダー簡略化 */
+@media (max-width: 767px) {
+  .header {
+    gap: var(--space-2, 8px);
+    margin-bottom: var(--space-3, 12px);
+  }
+
+  .round-info {
+    flex-wrap: wrap;
+    gap: var(--space-1, 4px);
+  }
+
+  .round-badge {
+    padding: var(--space-1, 4px) var(--space-3, 12px);
+    font-size: var(--font-size-sm, 13px);
+  }
+
+  .progress-bar {
+    max-width: 120px;
+    margin: 0 var(--space-2, 8px);
+    height: 4px;
+  }
+
+  .score-display {
+    padding: var(--space-1, 4px) var(--space-3, 12px);
+    gap: var(--space-1, 4px);
+  }
+
+  .score-label {
+    font-size: var(--font-size-xs, 11px);
+  }
+
+  .score-value {
+    font-size: var(--font-size-lg, 20px);
+  }
+
+  .rules-button {
+    font-size: var(--font-size-md, 16px);
+  }
+}
+
+/* タブレット (768px以上) */
+@media (min-width: 768px) {
+  .header {
+    gap: var(--space-3, 12px);
+  }
+
+  .progress-bar {
+    max-width: 150px;
+  }
+}
+
+/* PC (1024px以上) */
+@media (min-width: 1024px) {
+  .header {
+    gap: var(--space-4, 16px);
+  }
+
+  .progress-bar {
+    max-width: 200px;
+  }
+
+  .rules-button {
+    width: 48px;
+    height: 48px;
+    min-width: 48px;
+    min-height: 48px;
+  }
 }

--- a/src/pages/BattleScreen.module.css
+++ b/src/pages/BattleScreen.module.css
@@ -16,14 +16,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 30px;
-  margin-bottom: 15px;
+  gap: var(--space-8, 32px);
+  margin-bottom: var(--space-4, 16px);
   width: 100%;
   max-width: 900px;
 }
 
 .battle-vs {
-  font-size: 20px;
+  font-size: var(--font-size-xl, 24px);
   font-weight: 700;
   color: var(--color-accent, #c17f59);
 }
@@ -36,31 +36,31 @@
 
 /* Dealer area */
 .dealer-area {
-  margin-bottom: 10px;
+  margin-bottom: var(--space-3, 12px);
 }
 
 .dealer-header {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  margin-bottom: 8px;
+  gap: var(--space-2, 8px);
+  margin-bottom: var(--space-2, 8px);
 }
 
 .dealer-icon {
-  font-size: 16px;
+  font-size: var(--font-size-md, 16px);
 }
 
 .dealer-label {
-  font-size: 14px;
+  font-size: var(--font-size-base, 14px);
   color: var(--color-text-muted, #a89f94);
 }
 
 .hand-area-compact {
   background: var(--color-bg-light, #3d3a35);
   border-radius: var(--radius-xl, 20px);
-  padding: 15px;
-  margin: 5px 0;
+  padding: var(--space-4, 16px);
+  margin: var(--space-1, 4px) 0;
   box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
@@ -69,7 +69,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: 10px 0;
+  margin: var(--space-3, 12px) 0;
   width: 100%;
 }
 
@@ -86,10 +86,10 @@
 .vs-text {
   background: var(--color-accent, #c17f59);
   color: var(--color-text, #f5f0e8);
-  padding: 6px 16px;
-  border-radius: 20px;
+  padding: var(--space-2, 8px) var(--space-4, 16px);
+  border-radius: var(--radius-xl, 20px);
   font-weight: 700;
-  font-size: 16px;
+  font-size: var(--font-size-md, 16px);
 }
 
 .vs-row-right {
@@ -100,7 +100,7 @@
 
 /* Player area */
 .player-area {
-  margin-top: 10px;
+  margin-top: var(--space-3, 12px);
 }
 
 .hand-area {
@@ -118,20 +118,53 @@
   margin-bottom: var(--space-4, 16px);
 }
 
-/* Responsive styles */
+/* ==================== */
+/* Responsive Styles */
+/* ==================== */
+
+/* スマートフォン (767px以下) */
 @media (max-width: 767px) {
+  .screen {
+    padding: var(--space-3, 12px);
+  }
+
   .battle-roles-header {
-    gap: 15px;
+    gap: var(--space-3, 12px);
+    flex-wrap: wrap;
   }
 
   .battle-vs {
-    font-size: 16px;
+    font-size: var(--font-size-md, 16px);
+  }
+
+  .dealer-area {
+    margin-bottom: var(--space-2, 8px);
+  }
+
+  .dealer-header {
+    gap: var(--space-1, 4px);
+  }
+
+  .dealer-icon {
+    font-size: var(--font-size-sm, 13px);
+  }
+
+  .dealer-label {
+    font-size: var(--font-size-sm, 13px);
+  }
+
+  .hand-area-compact {
+    padding: var(--space-3, 12px);
   }
 
   .vs-row {
     flex-direction: column;
     align-items: center;
-    gap: var(--space-4, 16px);
+    gap: var(--space-3, 12px);
+  }
+
+  .vs-row-left {
+    display: none;
   }
 
   .vs-row-right {
@@ -139,11 +172,63 @@
     justify-content: center;
   }
 
+  .vs-text {
+    padding: var(--space-1, 4px) var(--space-3, 12px);
+    font-size: var(--font-size-sm, 13px);
+  }
+
+  .player-area {
+    margin-top: var(--space-2, 8px);
+  }
+
   .hand-area {
-    padding: var(--space-5, 20px) var(--space-4, 16px);
+    padding: var(--space-4, 16px);
   }
 
   .hand-label {
     font-size: var(--font-size-md, 16px);
+    margin-bottom: var(--space-2, 8px);
+  }
+}
+
+/* タブレット (768px以上) */
+@media (min-width: 768px) {
+  .battle-roles-header {
+    gap: var(--space-5, 20px);
+  }
+
+  .battle-vs {
+    font-size: var(--font-size-lg, 20px);
+  }
+
+  .hand-area-compact {
+    padding: var(--space-5, 20px);
+  }
+
+  .hand-area {
+    padding: var(--space-6, 24px);
+  }
+}
+
+/* PC (1024px以上) */
+@media (min-width: 1024px) {
+  .battle-roles-header {
+    gap: var(--space-8, 32px);
+  }
+
+  .battle-vs {
+    font-size: var(--font-size-xl, 24px);
+  }
+
+  .hand-area-compact {
+    padding: var(--space-6, 24px);
+  }
+
+  .hand-area {
+    padding: var(--space-8, 32px);
+  }
+
+  .hand-label {
+    font-size: var(--font-size-xl, 24px);
   }
 }

--- a/src/pages/GameScreen.module.css
+++ b/src/pages/GameScreen.module.css
@@ -13,7 +13,11 @@
   align-items: center;
   gap: var(--space-3, 12px);
   width: 100%;
-  max-width: 800px;
+  max-width: 900px;
+  background: var(--color-bg-light, #3d3a35);
+  border-radius: var(--radius-xl, 20px);
+  padding: var(--space-8, 32px);
+  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
 .hand-label {
@@ -21,4 +25,44 @@
   font-weight: 600;
   color: var(--color-text, #f5f0e8);
   text-align: center;
+}
+
+/* ==================== */
+/* Responsive Styles */
+/* ==================== */
+
+/* スマートフォン (767px以下) */
+@media (max-width: 767px) {
+  .screen {
+    padding: var(--space-3, 12px);
+  }
+
+  .hand-area {
+    padding: var(--space-4, 16px);
+    gap: var(--space-2, 8px);
+  }
+
+  .hand-label {
+    font-size: var(--font-size-md, 16px);
+  }
+}
+
+/* タブレット (768px以上) */
+@media (min-width: 768px) {
+  .hand-area {
+    padding: var(--space-6, 24px);
+    gap: var(--space-3, 12px);
+  }
+}
+
+/* PC (1024px以上) */
+@media (min-width: 1024px) {
+  .hand-area {
+    padding: var(--space-8, 32px);
+    gap: var(--space-4, 16px);
+  }
+
+  .hand-label {
+    font-size: var(--font-size-xl, 24px);
+  }
 }

--- a/src/pages/ResultScreen.module.css
+++ b/src/pages/ResultScreen.module.css
@@ -367,8 +367,16 @@
   gap: var(--space-3, 12px);
 }
 
-/* Responsive adjustments */
+/* ==================== */
+/* Responsive Styles */
+/* ==================== */
+
+/* スマートフォン (767px以下) */
 @media (max-width: 767px) {
+  .container {
+    padding: var(--space-4, 16px);
+  }
+
   .scoreValue {
     font-size: var(--font-size-4xl, 56px);
   }
@@ -427,6 +435,7 @@
   }
 }
 
+/* Very small screens */
 @media (max-width: 400px) {
   .content {
     padding: 0 var(--space-2, 8px);
@@ -434,6 +443,48 @@
 
   .scoreValue {
     font-size: 48px;
+  }
+}
+
+/* タブレット (768px以上) */
+@media (min-width: 768px) {
+  .content {
+    max-width: 550px;
+  }
+
+  .scoreTitle {
+    font-size: var(--font-size-2xl, 32px);
+  }
+
+  .scoreValue {
+    font-size: 80px;
+  }
+
+  .historySection {
+    padding: var(--space-6, 24px);
+  }
+}
+
+/* PC (1024px以上) */
+@media (min-width: 1024px) {
+  .content {
+    max-width: 600px;
+  }
+
+  .scoreValue {
+    font-size: 96px;
+  }
+
+  .finalResult {
+    font-size: 56px;
+  }
+
+  .historySection {
+    padding: var(--space-8, 32px);
+  }
+
+  .historyItem {
+    padding: var(--space-4, 16px) 0;
   }
 }
 

--- a/src/pages/TitleScreen.module.css
+++ b/src/pages/TitleScreen.module.css
@@ -85,18 +85,26 @@
 .titleCats {
   display: flex;
   justify-content: center;
-  gap: var(--space-4, 16px);
+  gap: var(--card-gap, 8px);
   margin-bottom: var(--space-12, 48px);
 }
 
 .titleCatCard {
-  width: 80px;
-  height: 107px;
+  width: var(--card-width, 80px);
+  height: var(--card-height, 107px);
   border-radius: var(--radius-md, 8px);
   overflow: hidden;
   box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.3));
   transform: rotate(var(--rotation));
   transition: transform var(--transition-normal, 0.3s);
+}
+
+/* タップ領域を確保 (タッチデバイス向け) */
+@media (hover: none) {
+  .titleCatCard {
+    min-width: var(--min-tap-size, 44px);
+    min-height: var(--min-tap-size, 44px);
+  }
 }
 
 .titleCatCard:hover {
@@ -159,6 +167,10 @@
 
 /* Responsive - Mobile (max-width: 767px) */
 @media (max-width: 767px) {
+  .titleScreen {
+    padding: var(--space-4, 16px);
+  }
+
   .titleText {
     font-size: var(--font-size-xl, 24px);
     letter-spacing: 2px;
@@ -180,9 +192,17 @@
     right: -6px;
   }
 
-  .titleCatCard {
-    width: 60px;
-    height: 80px;
+  .titleSubtitle {
+    font-size: var(--font-size-sm, 13px);
+    margin-bottom: var(--space-6, 24px);
+  }
+
+  .titleCats {
+    margin-bottom: var(--space-8, 32px);
+  }
+
+  .titleMenu {
+    max-width: 100%;
   }
 
   .titleFooter {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -22,46 +22,78 @@
   --color-danger: #c46b6b; /* 敗北（赤） */
 
   /* ==================== */
+  /* レスポンシブブレークポイント */
+  /* ==================== */
+
+  /* ブレークポイント定義
+   * --breakpoint-sm: 375px (スマートフォン)
+   * --breakpoint-md: 768px (タブレット)
+   * --breakpoint-lg: 1024px (PC、推奨)
+   */
+
+  /* ==================== */
   /* サイズ定義 */
   /* ==================== */
 
-  /* カードサイズ - PC */
+  /* カードサイズ - PC (1024px+) */
   --card-width-pc: 150px;
   --card-height-pc: 200px;
+  --card-gap-pc: 16px;
 
-  /* カードサイズ - SP */
+  /* カードサイズ - タブレット (768px-1023px) */
+  --card-width-tablet: 120px;
+  --card-height-tablet: 160px;
+  --card-gap-tablet: 12px;
+
+  /* カードサイズ - スマートフォン (375px-767px) */
   --card-width-sp: 80px;
   --card-height-sp: 107px;
+  --card-gap-sp: 8px;
 
   /* ディーラーカード（80%サイズ） */
   --dealer-card-width-pc: 120px;
   --dealer-card-height-pc: 160px;
+  --dealer-card-width-tablet: 96px;
+  --dealer-card-height-tablet: 128px;
+  --dealer-card-width-sp: 64px;
+  --dealer-card-height-sp: 86px;
 
   /* トランジション */
   --transition-fast: 0.2s;
   --transition-normal: 0.3s;
 
+  /* タッチ操作用最小サイズ */
+  --min-tap-size: 44px;
+
   /* ==================== */
-  /* レスポンシブ */
+  /* レスポンシブ変数（デフォルト: スマートフォン） */
   /* ==================== */
 
-  /* デフォルト: スマートフォン */
   --card-width: var(--card-width-sp);
   --card-height: var(--card-height-sp);
+  --card-gap: var(--card-gap-sp);
+  --dealer-card-width: var(--dealer-card-width-sp);
+  --dealer-card-height: var(--dealer-card-height-sp);
 }
 
-/* タブレット */
+/* タブレット (768px以上) */
 @media (min-width: 768px) {
   :root {
-    --card-width: 120px;
-    --card-height: 160px;
+    --card-width: var(--card-width-tablet);
+    --card-height: var(--card-height-tablet);
+    --card-gap: var(--card-gap-tablet);
+    --dealer-card-width: var(--dealer-card-width-tablet);
+    --dealer-card-height: var(--dealer-card-height-tablet);
   }
 }
 
-/* PC（推奨） */
+/* PC (1024px以上) */
 @media (min-width: 1024px) {
   :root {
     --card-width: var(--card-width-pc);
     --card-height: var(--card-height-pc);
+    --card-gap: var(--card-gap-pc);
+    --dealer-card-width: var(--dealer-card-width-pc);
+    --dealer-card-height: var(--dealer-card-height-pc);
   }
 }


### PR DESCRIPTION
## Summary

- 各画面のレスポンシブ対応を実装
- スマートフォン、タブレット、PCで適切なレイアウトが表示されるようにした

## Changes

- CSS変数にレスポンシブブレークポイント(375px, 768px, 1024px)を追加
- カードサイズをデバイスに応じて変更(SP: 80x107px, Tablet: 120x160px, PC: 150x200px)
- カード間隔をデバイスに応じて調整(SP: 8px, Tablet: 12px, PC: 16px)
- タイトル画面のレスポンシブ対応
- ゲーム画面のヘッダー簡略化とハンドエリアのレスポンシブ対応
- 対戦画面のディーラー/プレイヤーエリアのレスポンシブ対応
- 結果画面のスコア表示と履歴リストのレスポンシブ対応
- モーダルのスマートフォンでのフルスクリーン風表示
- タッチ操作サポート(最小タップ領域44x44px確保)

## Code Review Results

### 指摘事項と修正内容

| # | 指摘事項 | 対応内容 | 対応状況 |
|---|---------|---------|---------|
| - | 指摘事項なし | - | - |

## Test Results

- テスト実行結果: ✅ All tests passed (763/763)
- カバレッジ: 88.91% (CSSのみの変更のため影響なし)

## Related Issues

- Closes #26

## Checklist

- [x] コードレビュー実施済み
- [x] テスト追加・更新済み(CSSのみの変更)
- [x] mock/index.html との整合性確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)