### PR TITLE
ツーペアで一部のカードにアニメーションが適用されないバグを修正 (#62)

### DIFF
--- a/src/components/card/Hand.tsx
+++ b/src/components/card/Hand.tsx
@@ -156,10 +156,14 @@ export const Hand: React.FC<HandProps> = ({
         const isExchanging = exchangingCardIds.includes(card.id);
 
         // Determine animation type for this specific card
+        // Note: When a card is matching (part of winning hand), we skip the enter animation
+        // to allow the matching glow animation (cardGlowWithScale) to display properly.
+        // This fixes the issue where exchanged cards had no glow animation due to CSS
+        // animation property being overwritten by card--enter class.
         let cardAnimation: CardAnimationType = animationType;
         if (isExchanging) {
           cardAnimation = 'exchange';
-        } else if (isNew && animationType === 'none') {
+        } else if (isNew && animationType === 'none' && !isMatching) {
           cardAnimation = 'enter';
         }
 


### PR DESCRIPTION
## Summary

- ツーペア判定後、交換されたカードにも光るエフェクト（cardGlowWithScale）アニメーションが適用されるように修正
- CSSアニメーションの競合を解消：マッチングカードの場合はエンターアニメーションをスキップ

## Changes

- `src/components/card/Hand.tsx`: `isMatching`条件を追加してアニメーション優先順位を制御
- `src/components/card/__tests__/Hand.test.tsx`: Issue #62の修正に対するテストケースを3件追加
- `src/pages/__tests__/BattleScreen.test.tsx`: カバレッジ向上のためのテストケースを追加

## Code Review Results

### 指摘事項と修正内容

| # | 指摘事項 | 対応内容 | 対応状況 |
|---|---------|---------|---------|
| - | 指摘事項なし | - | - |

## Test Results

- テスト実行結果: All tests passed (804/804)
- カバレッジ: 95.51%

## Related Issues

Closes #62

## Checklist

- [x] コードレビュー実施済み
- [x] テスト追加・更新済み
- [x] mock/index.html との整合性確認済み（UIロジック変更のみ）

---
Generated with Claude Code