### PR TITLE
ソロモードでカード交換アニメーションが2回再生されるバグを修正 (#68)

### DIFF
--- a/src/pages/__tests__/GameScreen.test.tsx
+++ b/src/pages/__tests__/GameScreen.test.tsx
@@ -153,8 +153,14 @@ describe('GameScreen', () => {
         skipButton.click();
       });
 
+      // Wait for ROLE_HIGHLIGHT_DELAY (300ms) in GameScreen
       await act(async () => {
-        vi.advanceTimersByTime(200);
+        vi.advanceTimersByTime(400);
+      });
+
+      // Wait for ROLE_NAME_DELAY (200ms) in RoleDisplay
+      await act(async () => {
+        vi.advanceTimersByTime(300);
       });
 
       // Should show the role name
@@ -174,8 +180,9 @@ describe('GameScreen', () => {
         skipButton.click();
       });
 
+      // Wait for ROLE_HIGHLIGHT_DELAY (300ms) + buffer
       await act(async () => {
-        vi.advanceTimersByTime(200);
+        vi.advanceTimersByTime(400);
       });
 
       expect(screen.getByText(/次のラウンドへ/)).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- ソロモードでカード交換アニメーションが2回再生されるバグを修正
- BattleScreen.tsxのパターンに統一し、役判定ロジックの重複を解消

## Changes

- `revealRole`関数を引数化（手札を引数で渡す）
- `useEffect`による自動役判定を削除
- `handleExchange`/`handleSkipExchange`関数で手札を事前計算して`revealRole`に渡す
- テストの待機時間を遅延に合わせて調整

## Code Review Results

### 指摘事項と修正内容

| # | 指摘事項 | 対応内容 | 対応状況 |
|---|---------|---------|---------|
| - | 指摘事項なし | - | - |

## Test Results

- テスト実行結果: All tests passed (804/804)
- カバレッジ: 95.48%

## Related Issues

Closes #68

## Checklist

- [x] コードレビュー実施済み
- [x] テスト追加・更新済み
- [x] mock/index.html との整合性確認済み（UI変更なし）