### PR TITLE
ディーラーエリアのカード情報の行間を修正 (#72)

### DIFF
--- a/src/components/card/Hand.module.css
+++ b/src/components/card/Hand.module.css
@@ -48,6 +48,7 @@
 /* Dealer card info is slightly smaller */
 .hand--dealer .hand__card-wrapper [class*='card-info'] {
   font-size: var(--font-size-sm, 13px);
+  line-height: var(--line-height-tight, 1.2);
   min-height: 32px;
 }
 
@@ -55,6 +56,7 @@
 @media (max-width: 767px) {
   .hand--dealer .hand__card-wrapper [class*='card-info'] {
     font-size: var(--font-size-xs, 11px);
+    line-height: var(--line-height-tight, 1.2);
     min-height: 24px;
   }
 }
@@ -63,6 +65,7 @@
 @media (min-width: 768px) {
   .hand--dealer .hand__card-wrapper [class*='card-info'] {
     font-size: var(--font-size-sm, 13px);
+    line-height: var(--line-height-tight, 1.2);
     min-height: 28px;
   }
 }
@@ -71,6 +74,7 @@
 @media (min-width: 1024px) {
   .hand--dealer .hand__card-wrapper [class*='card-info'] {
     font-size: var(--font-size-base, 14px);
+    line-height: var(--line-height-tight, 1.2);
     min-height: 36px;
   }
 }


### PR DESCRIPTION
## Summary

- 対戦モードの勝敗結果画面で、ディーラーエリアのカード下に表示されるcolor（毛色）とfur（毛の長さ）の間のマージンが大きすぎる問題を修正

## Changes

- `src/components/card/Hand.module.css` のディーラー用CardInfoスタイルに `line-height: var(--line-height-tight, 1.2)` を追加
- 基本スタイルおよび3つのメディアクエリ（767px以下、768px以上、1024px以上）に同じline-heightを追加

## Code Review Results

### 指摘事項と修正内容

| # | 指摘事項 | 対応内容 | 対応状況 |
|---|---------|---------|---------|
| - | 指摘事項なし | - | - |

## Test Results

- テスト実行結果: All tests passed (859/859)
- カバレッジ: 95.65%

## Related Issues

Closes #72

## Checklist

- [x] コードレビュー実施済み
- [x] テスト追加・更新済み（既存テストで問題なし）
- [x] mock/index.html との整合性確認済み