### PR TITLE
CSSモジュール間のスタイルオーバーライド問題を修正

### DIFF
--- a/mock/styles.css
+++ b/mock/styles.css
@@ -706,7 +706,7 @@ body {
 
 .dealer-area .card-wrapper .card-info {
   font-size: 15px;
-  min-height: 40px;
+  min-height: auto;
 }
 
 .dealer-area .card-wrapper .card-info .card-fur {

--- a/src/components/card/CardInfo.module.css
+++ b/src/components/card/CardInfo.module.css
@@ -61,3 +61,9 @@
 .card-info--highlighted .card-info__color {
   color: var(--color-primary, #d4a574);
 }
+
+/* Compact variant (for dealer cards) */
+.card-info--compact {
+  min-height: auto;
+  gap: 0;
+}

--- a/src/components/card/CardInfo.tsx
+++ b/src/components/card/CardInfo.tsx
@@ -11,6 +11,8 @@ export interface CardInfoProps {
   isDimmed?: boolean;
   /** Highlight state (for matching cards) */
   isHighlighted?: boolean;
+  /** Compact layout (for dealer cards) */
+  isCompact?: boolean;
   /** Additional class name */
   className?: string;
 }
@@ -27,6 +29,7 @@ export const CardInfo: React.FC<CardInfoProps> = ({
   fur,
   isDimmed = false,
   isHighlighted = false,
+  isCompact = false,
   className,
 }) => {
   const colorName = COLOR_NAMES[color];
@@ -36,6 +39,7 @@ export const CardInfo: React.FC<CardInfoProps> = ({
     styles['card-info'],
     isDimmed && styles['card-info--dimmed'],
     isHighlighted && styles['card-info--highlighted'],
+    isCompact && styles['card-info--compact'],
     className,
   ]
     .filter(Boolean)

--- a/src/components/card/Hand.module.css
+++ b/src/components/card/Hand.module.css
@@ -54,12 +54,8 @@
   transform: none;
 }
 
-/* Dealer card info - same font size as player, compact layout */
-/* min-height: auto により、コンテンツに応じて自動調整される */
-.hand--dealer .hand__card-wrapper [class*='card-info'] {
-  min-height: auto;
-  gap: 0;
-}
+/* Dealer card info - compact layout is now handled via CardInfo's isCompact prop */
+/* This ensures styles are applied from within the CardInfo component */
 
 /* ==================== */
 /* Animation Delays */

--- a/src/components/card/Hand.tsx
+++ b/src/components/card/Hand.tsx
@@ -182,6 +182,7 @@ export const Hand: React.FC<HandProps> = ({
                 fur={card.fur}
                 isDimmed={isNotMatching}
                 isHighlighted={isMatching}
+                isCompact={isDealer}
               />
             )}
           </div>

--- a/src/components/card/__tests__/CardInfo.test.tsx
+++ b/src/components/card/__tests__/CardInfo.test.tsx
@@ -76,6 +76,23 @@ describe('CardInfo', () => {
       expect(container.firstChild?.className).toContain('card-info--dimmed');
       expect(container.firstChild?.className).toContain('card-info--highlighted');
     });
+
+    it('applies compact class when isCompact is true', () => {
+      const { container } = render(<CardInfo color={0} fur={1} isCompact />);
+      expect(container.firstChild?.className).toContain('card-info--compact');
+    });
+
+    it('does not apply compact class by default', () => {
+      const { container } = render(<CardInfo color={0} fur={1} />);
+      expect(container.firstChild?.className).not.toContain('card-info--compact');
+    });
+
+    it('can apply compact with other state classes', () => {
+      const { container } = render(<CardInfo color={0} fur={1} isCompact isDimmed isHighlighted />);
+      expect(container.firstChild?.className).toContain('card-info--compact');
+      expect(container.firstChild?.className).toContain('card-info--dimmed');
+      expect(container.firstChild?.className).toContain('card-info--highlighted');
+    });
   });
 
   describe('Structure', () => {

--- a/src/components/card/__tests__/Hand.test.tsx
+++ b/src/components/card/__tests__/Hand.test.tsx
@@ -178,6 +178,22 @@ describe('Hand', () => {
 
       expect(screen.getByText('茶トラ')).toBeInTheDocument();
     });
+
+    it('applies compact style to card info when isDealer is true', () => {
+      const cards = createMockCards();
+      const { container } = render(<Hand cards={cards} isDealer showCards />);
+
+      const compactInfos = container.querySelectorAll('[class*="card-info--compact"]');
+      expect(compactInfos.length).toBe(5);
+    });
+
+    it('does not apply compact style to card info for player hand', () => {
+      const cards = createMockCards();
+      const { container } = render(<Hand cards={cards} showCards />);
+
+      const compactInfos = container.querySelectorAll('[class*="card-info--compact"]');
+      expect(compactInfos.length).toBe(0);
+    });
   });
 
   describe('Matching cards', () => {


### PR DESCRIPTION
## Summary

- CSSモジュール間での属性セレクタ `[class*='card-info']` によるスタイルオーバーライドが機能しない問題を修正
- CardInfo コンポーネントに `isCompact` プロップを追加し、コンポーネント内部でスタイルを制御するように変更

## Changes

- `CardInfo.tsx`: `isCompact` プロップを追加
- `CardInfo.module.css`: `.card-info--compact` スタイルを追加
- `Hand.tsx`: `isDealer` の場合に `isCompact={true}` を渡すように変更
- `Hand.module.css`: 機能しない属性セレクタ `[class*='card-info']` を削除
- `mock/styles.css`: `.dealer-area .card-wrapper .card-info` の `min-height` を `auto` に修正

## Code Review Results

### 指摘事項と修正内容

指摘事項なし

このアプローチは以下の理由で適切です:
1. CSSモジュールの設計思想に沿っている（コンポーネントが自身の見た目を制御）
2. 属性セレクタを使用せず、クラス名による直接的なスタイル適用
3. 既存のパターン（isDimmed, isHighlighted）と一貫性がある

## Test Results

- テスト実行結果: All tests passed (864/864)
- カバレッジ: 95.65%

## Related Issues

Closes #81

## Checklist

- [x] コードレビュー実施済み
- [x] テスト追加・更新済み
- [x] mock/index.html との整合性確認済み（UI変更がある場合）