### PR TITLE
RulesModalのアコーディオン点滅バグを修正 (#93)

### DIFF
--- a/src/components/modals/RulesModal.module.css
+++ b/src/components/modals/RulesModal.module.css
@@ -31,16 +31,20 @@
   align-items: center;
   padding: var(--space-4, 16px);
   cursor: pointer;
-  list-style: none;
+  width: 100%;
+  border: none;
+  background: transparent;
+  text-align: left;
   transition: background var(--transition-fast, 0.2s);
-}
-
-.rulesAccordionHeader::-webkit-details-marker {
-  display: none;
 }
 
 .rulesAccordionHeader:hover {
   background: var(--color-bg-light, #3d3a35);
+}
+
+.rulesAccordionHeader:focus {
+  outline: 2px solid var(--color-primary, #d4a574);
+  outline-offset: -2px;
 }
 
 .accordionTitle {
@@ -81,13 +85,18 @@
   transition: transform var(--transition-fast, 0.2s), opacity var(--transition-fast, 0.2s);
 }
 
-.rulesAccordion[open] .accordionIcon::after {
+.accordionIconOpen::after {
   transform: rotate(90deg);
   opacity: 0;
 }
 
 .rulesAccordionContent {
   padding: 0 var(--space-4, 16px) var(--space-4, 16px);
+  display: none;
+}
+
+.rulesAccordionContentOpen {
+  display: block;
 }
 
 /* Role Table */

--- a/src/components/modals/RulesModal.tsx
+++ b/src/components/modals/RulesModal.tsx
@@ -87,16 +87,25 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
       </section>
 
       {/* Flush Roles Accordion */}
-      <details
-        className={styles.rulesAccordion}
-        open={flushAccordionOpen}
-        onToggle={handleFlushAccordionToggle}
-      >
-        <summary className={styles.rulesAccordionHeader}>
+      <div className={styles.rulesAccordion}>
+        <button
+          type="button"
+          className={styles.rulesAccordionHeader}
+          onClick={handleFlushAccordionToggle}
+          aria-expanded={flushAccordionOpen}
+          aria-controls="flush-accordion-content"
+        >
           <h3 className={styles.accordionTitle}>役一覧（フラッシュ系）</h3>
-          <span className={styles.accordionIcon} aria-hidden="true" />
-        </summary>
-        <div className={styles.rulesAccordionContent}>
+          <span
+            className={`${styles.accordionIcon} ${flushAccordionOpen ? styles.accordionIconOpen : ''}`}
+            aria-hidden="true"
+          />
+        </button>
+        <div
+          id="flush-accordion-content"
+          className={`${styles.rulesAccordionContent} ${flushAccordionOpen ? styles.rulesAccordionContentOpen : ''}`}
+          hidden={!flushAccordionOpen}
+        >
           <table className={styles.roleTable}>
             <thead>
               <tr>
@@ -116,19 +125,28 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
             </tbody>
           </table>
         </div>
-      </details>
+      </div>
 
       {/* Fur and Color Roles Accordion */}
-      <details
-        className={styles.rulesAccordion}
-        open={furColorAccordionOpen}
-        onToggle={handleFurColorAccordionToggle}
-      >
-        <summary className={styles.rulesAccordionHeader}>
+      <div className={styles.rulesAccordion}>
+        <button
+          type="button"
+          className={styles.rulesAccordionHeader}
+          onClick={handleFurColorAccordionToggle}
+          aria-expanded={furColorAccordionOpen}
+          aria-controls="fur-color-accordion-content"
+        >
           <h3 className={styles.accordionTitle}>役一覧（ファー系・カラー系）</h3>
-          <span className={styles.accordionIcon} aria-hidden="true" />
-        </summary>
-        <div className={styles.rulesAccordionContent}>
+          <span
+            className={`${styles.accordionIcon} ${furColorAccordionOpen ? styles.accordionIconOpen : ''}`}
+            aria-hidden="true"
+          />
+        </button>
+        <div
+          id="fur-color-accordion-content"
+          className={`${styles.rulesAccordionContent} ${furColorAccordionOpen ? styles.rulesAccordionContentOpen : ''}`}
+          hidden={!furColorAccordionOpen}
+        >
           <p className={styles.rulesNote}>
             ※カラー系の役は毛色ごとに異なるポイントがあります（代表的なポイントを表示）
           </p>
@@ -184,7 +202,7 @@ export const RulesModal: React.FC<RulesModalProps> = ({ isOpen, onClose }) => {
             </tbody>
           </table>
         </div>
-      </details>
+      </div>
     </Modal>
   );
 };


### PR DESCRIPTION
## Summary

- RulesModalでdetails要素のopen属性とReact状態の競合によって発生していたモーダル点滅バグを修正
- `<details>` + `<summary>`を`<div>` + `<button>`ベースのカスタムアコーディオンに置き換え
- アクセシビリティ属性(aria-expanded, aria-controls)を適切に設定

## Changes

- `RulesModal.tsx`: `<details>`を`<div>` + `<button>`ベースのカスタムアコーディオンに置き換え
- `RulesModal.module.css`: summary要素のスタイルをbutton要素用に変更、フォーカススタイルを追加
- `RulesModal.test.tsx`: 新しいDOM構造に合わせてテストを更新、アクセシビリティテストを追加

## Code Review Results

### 指摘事項と修正内容

| # | 指摘事項 | 対応内容 | 対応状況 |
|---|---------|---------|---------|
| - | 指摘事項なし | - | - |

## Test Results

- テスト実行結果: All tests passed (896/896)
- カバレッジ: 97.94%

## Related Issues

Closes #93

## Checklist

- [x] コードレビュー実施済み
- [x] テスト追加・更新済み
- [x] mock/index.html との整合性確認済み（UI変更がある場合）